### PR TITLE
Ensure API backward compatibility

### DIFF
--- a/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
+++ b/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
@@ -1,6 +1,9 @@
 package org.swisspush.redisques.util;
 
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.swisspush.redisques.RedisQues;
 
 /**
  * Class RedisquesAPI listing the operations and response values which are supported in Redisques.
@@ -23,14 +26,47 @@ public class RedisquesAPI {
     public static final String REQUESTED_BY = "requestedBy";
     public static final String NO_SUCH_LOCK = "No such lock";
 
+    private static Logger log = LoggerFactory.getLogger(RedisquesAPI.class);
+
     public enum QueueOperation {
-        enqueue, check, reset, stop, getQueueItems, addQueueItem, deleteQueueItem,
-        getQueueItem, replaceQueueItem, deleteAllQueueItems, getAllLocks, putLock,
-        getLock, deleteLock, getQueues, getQueuesCount, getQueueItemsCount;
+        enqueue(null),
+        check(null),
+        reset(null),
+        stop(null),
+        getQueueItems("getListRange"),
+        addQueueItem("addItem"),
+        deleteQueueItem("deleteItem"),
+        getQueueItem("getItem"),
+        replaceQueueItem("replaceItem"),
+        deleteAllQueueItems(null),
+        getAllLocks(null),
+        putLock(null),
+        getLock(null),
+        deleteLock(null),
+        getQueues(null),
+        getQueuesCount(null),
+        getQueueItemsCount(null);
+
+        private final String legacyName;
+
+        QueueOperation(String legacyName){
+            this.legacyName = legacyName;
+        }
+
+        public String getLegacyName() {
+            return legacyName;
+        }
+
+        public boolean hasLegacyName(){
+            return legacyName != null;
+        }
 
         public static QueueOperation fromString(String op){
             for (QueueOperation queueOperation : values()) {
                 if(queueOperation.name().equalsIgnoreCase(op)){
+                    return queueOperation;
+                } else if(queueOperation.hasLegacyName() && queueOperation.getLegacyName().equalsIgnoreCase(op)){
+                    log.warn("Legacy queue operation used. This may be removed in future releases. Use '"+queueOperation.name()+"' instead of '" + queueOperation.getLegacyName() + "'");
                     return queueOperation;
                 }
             }

--- a/src/test/java/org/swisspush/redisques/util/RedisquesAPITest.java
+++ b/src/test/java/org/swisspush/redisques/util/RedisquesAPITest.java
@@ -1,0 +1,86 @@
+package org.swisspush.redisques.util;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.swisspush.redisques.util.RedisquesAPI.*;
+
+/**
+ * Tests for {@link RedisquesAPI} class.
+ *
+ * @author https://github.com/mcweba [Marc-Andre Weber]
+ */
+@RunWith(VertxUnitRunner.class)
+public class RedisquesAPITest {
+
+    @Test
+    public void testQueueOperationFromString(TestContext context){
+        context.assertNull(QueueOperation.fromString("abc"));
+        context.assertNull(QueueOperation.fromString("dummy"));
+        context.assertNull(QueueOperation.fromString("doEnqueueThisItemPlease"));
+
+        context.assertEquals(QueueOperation.check, QueueOperation.fromString("check"));
+        context.assertEquals(QueueOperation.check, QueueOperation.fromString("CHECK"));
+
+        context.assertEquals(QueueOperation.getAllLocks, QueueOperation.fromString("getAllLocks"));
+        context.assertEquals(QueueOperation.getAllLocks, QueueOperation.fromString("getallLOCKS"));
+
+        context.assertEquals(QueueOperation.getQueueItems, QueueOperation.fromString("getListRange")); // legacy
+        context.assertEquals(QueueOperation.getQueueItems, QueueOperation.fromString("GETLISTRANGE")); // legacy
+        context.assertEquals(QueueOperation.getQueueItems, QueueOperation.fromString("getQueueItems"));
+
+        context.assertEquals(QueueOperation.addQueueItem, QueueOperation.fromString("addItem")); // legacy
+        context.assertEquals(QueueOperation.addQueueItem, QueueOperation.fromString("addITEM")); // legacy
+        context.assertEquals(QueueOperation.addQueueItem, QueueOperation.fromString("addQueueItem"));
+        context.assertEquals(QueueOperation.addQueueItem, QueueOperation.fromString("addQUEUEItem"));
+
+        context.assertEquals(QueueOperation.deleteQueueItem, QueueOperation.fromString("deleteItem")); // legacy
+        context.assertEquals(QueueOperation.deleteQueueItem, QueueOperation.fromString("DELETEItem")); // legacy
+        context.assertEquals(QueueOperation.deleteQueueItem, QueueOperation.fromString("deleteQueueItem"));
+        context.assertEquals(QueueOperation.deleteQueueItem, QueueOperation.fromString("DELETEQueueItem"));
+
+        context.assertEquals(QueueOperation.getQueueItem, QueueOperation.fromString("getItem")); // legacy
+        context.assertEquals(QueueOperation.getQueueItem, QueueOperation.fromString("getitem")); // legacy
+        context.assertEquals(QueueOperation.getQueueItem, QueueOperation.fromString("getQueueItem"));
+        context.assertEquals(QueueOperation.getQueueItem, QueueOperation.fromString("GETQueUEItem"));
+
+        context.assertEquals(QueueOperation.replaceQueueItem, QueueOperation.fromString("replaceItem")); // legacy
+        context.assertEquals(QueueOperation.replaceQueueItem, QueueOperation.fromString("replACeIteM")); // legacy
+        context.assertEquals(QueueOperation.replaceQueueItem, QueueOperation.fromString("replaceQueueItem"));
+        context.assertEquals(QueueOperation.replaceQueueItem, QueueOperation.fromString("REPLACEQUEUEITEM"));
+
+        context.assertEquals(QueueOperation.getQueues, QueueOperation.fromString("getQueues"));
+        context.assertEquals(QueueOperation.getQueuesCount, QueueOperation.fromString("getQueuesCount"));
+        context.assertEquals(QueueOperation.getQueueItemsCount, QueueOperation.fromString("getQueueItemsCount"));
+    }
+
+    @Test
+    public void testLegacyName(TestContext context){
+        context.assertTrue(QueueOperation.getQueueItems.hasLegacyName());
+        context.assertTrue(QueueOperation.addQueueItem.hasLegacyName());
+        context.assertTrue(QueueOperation.deleteQueueItem.hasLegacyName());
+        context.assertTrue(QueueOperation.getQueueItem.hasLegacyName());
+        context.assertTrue(QueueOperation.replaceQueueItem.hasLegacyName());
+
+        context.assertEquals("getListRange", QueueOperation.getQueueItems.getLegacyName());
+        context.assertEquals("addItem", QueueOperation.addQueueItem.getLegacyName());
+        context.assertEquals("deleteItem", QueueOperation.deleteQueueItem.getLegacyName());
+        context.assertEquals("getItem", QueueOperation.getQueueItem.getLegacyName());
+        context.assertEquals("replaceItem", QueueOperation.replaceQueueItem.getLegacyName());
+
+        context.assertFalse(QueueOperation.enqueue.hasLegacyName());
+        context.assertFalse(QueueOperation.check.hasLegacyName());
+        context.assertFalse(QueueOperation.reset.hasLegacyName());
+        context.assertFalse(QueueOperation.stop.hasLegacyName());
+        context.assertFalse(QueueOperation.deleteAllQueueItems.hasLegacyName());
+        context.assertFalse(QueueOperation.getAllLocks.hasLegacyName());
+        context.assertFalse(QueueOperation.putLock.hasLegacyName());
+        context.assertFalse(QueueOperation.getLock.hasLegacyName());
+        context.assertFalse(QueueOperation.deleteLock.hasLegacyName());
+        context.assertFalse(QueueOperation.getQueues.hasLegacyName());
+        context.assertFalse(QueueOperation.getQueuesCount.hasLegacyName());
+        context.assertFalse(QueueOperation.getQueueItemsCount.hasLegacyName());
+    }
+}


### PR DESCRIPTION
Ensured API backward compatibility by allowing the "old" queue operation names to work too.

Tests: https://drone.io/github.com/mcweba/vertx-redisques/48

Please review and merge