### PR TITLE
Pull Request for issue #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ The following configuration values are available:
 | address | redisques | The eventbus address the redisques module is listening to |
 | redis-prefix | redisques: | Prefix for redis keys holding queues and consumers |
 | processor-address | redisques-processor | Address of message processors |
-| refresh-period | 10 | The frequency of consumers refreshing their subscriptions to consume |
+| refresh-period | 10 | The frequency [s] of consumers refreshing their subscriptions to consume |
 | redisHost | localhost | The host where redis is running on |
 | redisPort | 6379 | The port where redis is running on |
 | redisEncoding | UTF-8 | The encoding to use in redis |
+| cleanupInterval | 60 | The interval [s] to cleanup timestamps of not-active / empty queues by executing **check** queue operation. _cleanupInterval_ value must be greater 0, otherwise the default is used. |
 
 ### Configuration util
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ modname=redisques
 version=2.2.1
 
 gradleVersion=2.3
-vertxVersion=3.2.0
+vertxVersion=3.2.1
 toolsVersion=2.0.3-final
 junitVersion=4.10
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,5 +6,6 @@ gradleVersion=2.3
 vertxVersion=3.2.1
 toolsVersion=2.0.3-final
 junitVersion=4.10
+commonscodecVersion=1.9
 
 runModArgs=-conf conf.json

--- a/gradle/vertx.gradle
+++ b/gradle/vertx.gradle
@@ -69,6 +69,10 @@ dependencies {
     provided "io.vertx:vertx-redis-client:$vertxVersion"
     provided "org.springframework:spring-core:4.1.6.RELEASE"
 
+    compile "commons-codec:commons-codec:$commonscodecVersion"
+
+    runtime "commons-codec:commons-codec:$commonscodecVersion"
+
     testCompile "junit:junit:$junitVersion"
     testCompile "io.vertx:vertx-unit:$vertxVersion"
     testCompile 'com.github.kstyrc:embedded-redis:0.6'

--- a/src/main/java/org/swisspush/redisques/lua/LuaScript.java
+++ b/src/main/java/org/swisspush/redisques/lua/LuaScript.java
@@ -1,0 +1,15 @@
+package org.swisspush.redisques.lua;
+
+public enum LuaScript {
+    CLEANUP("redisques_cleanup.lua");
+
+    private String file;
+
+    LuaScript(String file) {
+        this.file = file;
+    }
+
+    public String getFile() {
+        return file;
+    }
+}

--- a/src/main/java/org/swisspush/redisques/lua/LuaScriptManager.java
+++ b/src/main/java/org/swisspush/redisques/lua/LuaScriptManager.java
@@ -1,0 +1,106 @@
+package org.swisspush.redisques.lua;
+
+import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.redis.RedisClient;
+
+import java.util.*;
+
+/**
+ * Manages the lua scripts.
+ *
+ * @author https://github.com/mcweba [Marc-Andre Weber]
+ */
+public class LuaScriptManager {
+
+    private RedisClient redisClient;
+    private Map<LuaScript,LuaScriptState> luaScripts = new HashMap<>();
+    private Logger log = LoggerFactory.getLogger(LuaScriptManager.class);
+
+    public LuaScriptManager(RedisClient redisClient){
+        this.redisClient = redisClient;
+
+        LuaScriptState luaGetScriptState = new LuaScriptState(LuaScript.CLEANUP, redisClient, false);
+        luaGetScriptState.loadLuaScript(new RedisCommandDoNothing(), 0);
+        luaScripts.put(LuaScript.CLEANUP, luaGetScriptState);
+    }
+
+    /**
+     * If the loglevel is trace and the logoutput in luaScriptState is false, then reload the script with logoutput and execute the RedisCommand.
+     * If the loglevel is not trace and the logoutput in luaScriptState is true, then reload the script without logoutput and execute the RedisCommand.
+     * If the loglevel is matching the luaScriptState, just execute the RedisCommand.
+     *
+     * @param luaScript the type of lua script
+     * @param redisCommand the redis command to execute
+     * @param executionCounter current count of already passed executions
+     */
+    private void reloadScriptIfLoglevelChangedAndExecuteRedisCommand(LuaScript luaScript, RedisCommand redisCommand, int executionCounter) {
+        boolean logoutput = log.isTraceEnabled();
+        LuaScriptState luaScriptState = luaScripts.get(luaScript);
+        // if the loglevel didn't change, execute the command and return
+        if(logoutput == luaScriptState.getLogoutput()) {
+            redisCommand.exec(executionCounter);
+            return;
+            // if the loglevel changed, set the new loglevel into the luaScriptState, recompose the script and provide the redisCommand as parameter to execute
+        } else if(logoutput && ! luaScriptState.getLogoutput()) {
+            luaScriptState.setLogoutput(true);
+            luaScriptState.recomposeLuaScript();
+
+        } else if(! logoutput && luaScriptState.getLogoutput()) {
+            luaScriptState.setLogoutput(false);
+            luaScriptState.recomposeLuaScript();
+        }
+        luaScriptState.loadLuaScript(redisCommand, executionCounter);
+    }
+
+    public void handleQueueCleanup(String lastCleanupExecKey, int cleanupInterval, Handler<Boolean> handler){
+        List<String> keys = Collections.singletonList(lastCleanupExecKey);
+        List<String> arguments = Arrays.asList(
+                String.valueOf(System.currentTimeMillis()),
+                String.valueOf(cleanupInterval)
+        );
+        reloadScriptIfLoglevelChangedAndExecuteRedisCommand(LuaScript.CLEANUP, new Cleanup(keys, arguments, redisClient, handler), 0);
+    }
+
+    private class Cleanup implements RedisCommand {
+
+        private List<String> keys;
+        private List<String> arguments;
+        private Handler<Boolean> handler;
+        private RedisClient redisClient;
+
+        public Cleanup(List<String> keys, List<String> arguments, RedisClient redisClient, final Handler<Boolean> handler) {
+            this.keys = keys;
+            this.arguments = arguments;
+            this.redisClient = redisClient;
+            this.handler = handler;
+        }
+
+        @Override
+        public void exec(int executionCounter) {
+            redisClient.evalsha(luaScripts.get(LuaScript.CLEANUP).getSha(), keys, arguments, event -> {
+                if(event.succeeded()){
+                    Long value = event.result().getLong(0);
+                    if (log.isTraceEnabled()) {
+                        log.trace("Cleanup lua script got result: " + value);
+                    }
+                    handler.handle(value == 1L);
+                } else {
+                    String message = event.cause().getMessage();
+                    if(message != null && message.startsWith("NOSCRIPT")) {
+                        log.warn("cleanup script couldn't be found, reload it");
+                        log.warn("amount the script got loaded: " + String.valueOf(executionCounter));
+                        if(executionCounter > 10) {
+                            log.error("amount the script got loaded is higher than 10, we abort");
+                        } else {
+                            luaScripts.get(LuaScript.CLEANUP).loadLuaScript(new Cleanup(keys, arguments, redisClient, handler), executionCounter);
+                        }
+                    } else {
+                        log.error("Cleanup request failed with message: " + message);
+                    }
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/org/swisspush/redisques/lua/LuaScriptState.java
+++ b/src/main/java/org/swisspush/redisques/lua/LuaScriptState.java
@@ -1,0 +1,138 @@
+package org.swisspush.redisques.lua;
+
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.redis.RedisClient;
+import org.apache.commons.codec.digest.DigestUtils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * Holds the state of a lua script.
+ */
+public class LuaScriptState {
+
+    private LuaScript luaScriptType;
+    /** the script itself */
+    private String script;
+    /** if the script logs to the redis log */
+    private boolean logoutput = false;
+    /** the sha, over which the script can be accessed in redis */
+    private String sha;
+
+    private RedisClient redisClient;
+
+    private Logger log = LoggerFactory.getLogger(LuaScriptState.class);
+
+    public LuaScriptState(LuaScript luaScriptType, RedisClient redisClient, boolean logoutput) {
+        this.luaScriptType = luaScriptType;
+        this.redisClient = redisClient;
+        this.logoutput = logoutput;
+        this.composeLuaScript(luaScriptType);
+        this.loadLuaScript(new RedisCommandDoNothing(), 0);
+    }
+
+    /**
+     * Reads the script from the classpath and removes logging output if logoutput is false.
+     * The script is stored in the class member script.
+     * @param luaScriptType
+     */
+    private void composeLuaScript(LuaScript luaScriptType) {
+        log.info("read the lua script for script type: " + luaScriptType + " with logoutput: " + logoutput);
+        this.script = readLuaScriptFromClasspath(luaScriptType);
+        this.sha = DigestUtils.sha1Hex(this.script);
+    }
+
+    private String readLuaScriptFromClasspath(LuaScript luaScriptType) {
+        BufferedReader in = new BufferedReader(new InputStreamReader(this.getClass().getClassLoader().getResourceAsStream(luaScriptType.getFile())));
+        StringBuilder sb;
+        try {
+            sb = new StringBuilder();
+            String line;
+            while ((line = in.readLine()) != null) {
+                if (!logoutput && line.contains("redis.log(redis.LOG_NOTICE,")) {
+                    continue;
+                }
+                sb.append(line).append("\n");
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            try {
+                in.close();
+            } catch (IOException e) {
+                // Ignore
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Rereads the lua script, eg. if the loglevel changed.
+     */
+    public void recomposeLuaScript() {
+        this.composeLuaScript(luaScriptType);
+    }
+
+    /**
+     * Load the get script into redis and store the sha in the class member sha.
+     * @param redisCommand the redis command that should be executed, after the script is loaded.
+     * @param executionCounter a counter to control recursion depth
+     */
+    public void loadLuaScript(final RedisCommand redisCommand, int executionCounter) {
+        final int executionCounterIncr = ++executionCounter;
+
+        // check first if the lua script already exists in the store
+        redisClient.scriptExists(this.sha, resultArray -> {
+            if(resultArray.failed()){
+                log.error("Error checking whether lua script exists", resultArray.cause());
+                return;
+            }
+            Long exists = resultArray.result().getLong(0);
+            // if script already
+            if(Long.valueOf(1).equals(exists)) {
+                log.debug("RedisStorage script already exists in redis cache: " + luaScriptType);
+                redisCommand.exec(executionCounterIncr);
+            } else {
+                log.info("load lua script for script type: " + luaScriptType + " logutput: " + logoutput);
+                redisClient.scriptLoad(script, stringAsyncResult -> {
+                    String newSha = stringAsyncResult.result();
+                    log.info("got sha from redis for lua script: " + luaScriptType + ": " + newSha);
+                    if(!newSha.equals(sha)) {
+                        log.warn("the sha calculated by myself: " + sha + " doesn't match with the sha from redis: " + newSha + ". We use the sha from redis");
+                    }
+                    sha = newSha;
+                    log.info("execute redis command for script type: " + luaScriptType + " with new sha: " + sha);
+                    redisCommand.exec(executionCounterIncr);
+                });
+            }
+        });
+    }
+
+    public String getScript() {
+        return script;
+    }
+
+    public void setScript(String script) {
+        this.script = script;
+    }
+
+    public boolean getLogoutput() {
+        return logoutput;
+    }
+
+    public void setLogoutput(boolean logoutput) {
+        this.logoutput = logoutput;
+    }
+
+    public String getSha() {
+        return sha;
+    }
+
+    public void setSha(String sha) {
+        this.sha = sha;
+    }
+}

--- a/src/main/java/org/swisspush/redisques/lua/RedisCommand.java
+++ b/src/main/java/org/swisspush/redisques/lua/RedisCommand.java
@@ -1,0 +1,8 @@
+package org.swisspush.redisques.lua;
+
+/**
+ * @author https://github.com/mcweba [Marc-Andre Weber]
+ */
+public interface RedisCommand {
+    void exec(int executionCounter);
+}

--- a/src/main/java/org/swisspush/redisques/lua/RedisCommandDoNothing.java
+++ b/src/main/java/org/swisspush/redisques/lua/RedisCommandDoNothing.java
@@ -1,0 +1,11 @@
+package org.swisspush.redisques.lua;
+
+/**
+ * @author https://github.com/mcweba [Marc-Andre Weber]
+ */
+public class RedisCommandDoNothing implements RedisCommand{
+    @Override
+    public void exec(int executionCounter) {
+        // do nothing here
+    }
+}

--- a/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
+++ b/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
@@ -3,7 +3,6 @@ package org.swisspush.redisques.util;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import org.swisspush.redisques.RedisQues;
 
 /**
  * Class RedisquesAPI listing the operations and response values which are supported in Redisques.

--- a/src/main/resources/redisques_cleanup.lua
+++ b/src/main/resources/redisques_cleanup.lua
@@ -1,0 +1,11 @@
+local path = KEYS[1]
+local lastExecTS = tonumber(ARGV[1])
+local interval = tonumber(ARGV[2])
+
+local result = redis.call('set',path,lastExecTS,'NX','EX',interval)
+
+if result then
+    return 1
+else
+    return 0
+end

--- a/src/test/java/org/swisspush/redisques/AbstractTestCase.java
+++ b/src/test/java/org/swisspush/redisques/AbstractTestCase.java
@@ -42,8 +42,9 @@ public abstract class AbstractTestCase {
     @Rule
     public Timeout rule = Timeout.seconds(5);
 
-    static Vertx vertx;
     static Logger log = LoggerFactory.getLogger(AbstractTestCase.class);
+
+    protected static Vertx vertx;
     protected static Jedis jedis;
 
     protected void flushAll(){

--- a/src/test/java/org/swisspush/redisques/lua/AbstractLuaScriptTest.java
+++ b/src/test/java/org/swisspush/redisques/lua/AbstractLuaScriptTest.java
@@ -1,0 +1,93 @@
+package org.swisspush.redisques.lua;
+
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.swisspush.redisques.RedisEmbeddedConfiguration;
+import redis.clients.jedis.Jedis;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+
+/**
+ * Abstract class containing common methods for LuaScript tests
+ */
+@RunWith(VertxUnitRunner.class)
+public abstract class AbstractLuaScriptTest {
+
+    Jedis jedis = null;
+
+    @BeforeClass
+    public static void config() {
+        if(!RedisEmbeddedConfiguration.useExternalRedis()) {
+            RedisEmbeddedConfiguration.redisServer.start();
+        }
+    }
+
+    @AfterClass
+    public static void stopRedis() {
+        if(!RedisEmbeddedConfiguration.useExternalRedis()) {
+            RedisEmbeddedConfiguration.redisServer.stop();
+        }
+    }
+
+    @Before
+    public void connect() {
+        jedis = new Jedis("localhost", 6379, 5000);
+    }
+
+    @After
+    public void disconnect() {
+        jedis.flushAll();
+        jedis.close();
+    }
+
+    protected String readScript(String scriptFileName) {
+        return readScript(scriptFileName, false);
+    }
+
+    protected String readScript(String scriptFileName, boolean stripLogNotice) {
+        BufferedReader in = new BufferedReader(new InputStreamReader(this.getClass().getClassLoader().getResourceAsStream(scriptFileName)));
+        StringBuilder sb;
+        try {
+            sb = new StringBuilder();
+            String line;
+            while ((line = in.readLine()) != null) {
+                if (stripLogNotice && line.contains("redis.LOG_NOTICE,")) {
+                    continue;
+                }
+                sb.append(line + "\n");
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            try {
+                in.close();
+            } catch (IOException e) {
+                // Ignore
+            }
+        }
+        return sb.toString();
+    }
+
+    protected Object evalScriptCleanup(String lastCleanupExecKey, int cleanupInterval) {
+        String cleanupScript = readScript("redisques_cleanup.lua");
+        return jedis.eval(cleanupScript, new ArrayList() {
+                    {
+                        add(lastCleanupExecKey);
+                    }
+                }, new ArrayList() {
+                    {
+                        add(String.valueOf(System.currentTimeMillis()));
+                        add(String.valueOf(cleanupInterval));
+                    }
+                }
+        );
+    }
+}

--- a/src/test/java/org/swisspush/redisques/lua/RedisCleanupLuaScriptTests.java
+++ b/src/test/java/org/swisspush/redisques/lua/RedisCleanupLuaScriptTests.java
@@ -1,0 +1,32 @@
+package org.swisspush.redisques.lua;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+public class RedisCleanupLuaScriptTests extends AbstractLuaScriptTest {
+
+    private final String key = "queue_cleanup_lastexec";
+
+    @Test
+    public void testCleanup() throws InterruptedException {
+        assertThat(jedis.get(key), nullValue());
+        assertThat(evalScriptCleanup(key, 2), equalTo(1L));
+        String lastExecTS = jedis.get(key);
+
+        assertThat(evalScriptCleanup(key, 30), equalTo(0L));
+        assertThat(jedis.get(key), equalTo(lastExecTS));
+        assertThat(evalScriptCleanup(key, 30), equalTo(0L));
+        assertThat(jedis.get(key), equalTo(lastExecTS));
+        assertThat(evalScriptCleanup(key, 30), equalTo(0L));
+        assertThat(jedis.get(key), equalTo(lastExecTS));
+
+        Thread.sleep(2500); //wait 2.5 seconds
+
+        assertThat(jedis.get(key), nullValue());
+        assertThat(evalScriptCleanup(key, 2), equalTo(1L));
+        assertThat(jedis.get(key), notNullValue());
+        assertThat(jedis.get(key), not(equalTo(lastExecTS)));
+    }
+}

--- a/src/test/java/org/swisspush/redisques/util/RedisquesConfigurationTest.java
+++ b/src/test/java/org/swisspush/redisques/util/RedisquesConfigurationTest.java
@@ -25,6 +25,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(config.getRedisHost(), "localhost");
         testContext.assertEquals(config.getRedisPort(), 6379);
         testContext.assertEquals(config.getRedisEncoding(), "UTF-8");
+        testContext.assertEquals(config.getCleanupInterval(), 60);
     }
 
     @Test
@@ -33,6 +34,7 @@ public class RedisquesConfigurationTest {
                 .address("new_address")
                 .redisHost("anotherhost")
                 .redisPort(1234)
+                .cleanupInterval(5)
                 .build();
 
         // default values
@@ -45,6 +47,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(config.getAddress(), "new_address");
         testContext.assertEquals(config.getRedisHost(), "anotherhost");
         testContext.assertEquals(config.getRedisPort(), 1234);
+        testContext.assertEquals(config.getCleanupInterval(), 5);
     }
 
     @Test
@@ -59,6 +62,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(json.getString(PROP_REDIS_HOST), "localhost");
         testContext.assertEquals(json.getInteger(PROP_REDIS_PORT), 6379);
         testContext.assertEquals(json.getString(PROP_REDIS_ENCODING), "UTF-8");
+        testContext.assertEquals(json.getInteger(PROP_CLEANUP_INTERVAL), 60);
     }
 
     @Test
@@ -68,6 +72,7 @@ public class RedisquesConfigurationTest {
                 .address("new_address")
                 .redisHost("anotherhost")
                 .redisPort(1234)
+                .cleanupInterval(5)
                 .build();
 
         JsonObject json = config.asJsonObject();
@@ -82,6 +87,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(json.getString(PROP_ADDRESS), "new_address");
         testContext.assertEquals(json.getString(PROP_REDIS_HOST), "anotherhost");
         testContext.assertEquals(json.getInteger(PROP_REDIS_PORT), 1234);
+        testContext.assertEquals(json.getInteger(PROP_CLEANUP_INTERVAL), 5);
     }
 
     @Test
@@ -96,6 +102,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(config.getRedisHost(), "localhost");
         testContext.assertEquals(config.getRedisPort(), 6379);
         testContext.assertEquals(config.getRedisEncoding(), "UTF-8");
+        testContext.assertEquals(config.getCleanupInterval(), 60);
     }
 
     @Test
@@ -109,6 +116,7 @@ public class RedisquesConfigurationTest {
         json.put(PROP_REDIS_HOST, "newredishost");
         json.put(PROP_REDIS_PORT, 4321);
         json.put(PROP_REDIS_ENCODING, "new_encoding");
+        json.put(PROP_CLEANUP_INTERVAL, 5);
 
         RedisquesConfiguration config = fromJsonObject(json);
         testContext.assertEquals(config.getAddress(), "new_address");
@@ -118,6 +126,52 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(config.getRedisHost(), "newredishost");
         testContext.assertEquals(config.getRedisPort(), 4321);
         testContext.assertEquals(config.getRedisEncoding(), "new_encoding");
+        testContext.assertEquals(config.getCleanupInterval(), 5);
     }
 
+    @Test
+    public void testCleanupInterval(TestContext testContext){
+        int additional = 500;
+        RedisquesConfiguration config = with().cleanupInterval(5).build();
+        testContext.assertEquals(5, config.getCleanupInterval());
+        testContext.assertEquals(add500ms(2500), config.getCleanupIntervalTimerMs());
+
+        config = with().cleanupInterval(1).build();
+        testContext.assertEquals(1, config.getCleanupInterval());
+        testContext.assertEquals(add500ms(500), config.getCleanupIntervalTimerMs());
+
+        config = with().cleanupInterval(2).build();
+        testContext.assertEquals(2, config.getCleanupInterval());
+        testContext.assertEquals(add500ms(1000), config.getCleanupIntervalTimerMs());
+
+        config = with().cleanupInterval(3).build();
+        testContext.assertEquals(3, config.getCleanupInterval());
+        testContext.assertEquals(add500ms(1500), config.getCleanupIntervalTimerMs());
+
+        config = with().cleanupInterval(7).build();
+        testContext.assertEquals(7, config.getCleanupInterval());
+        testContext.assertEquals(add500ms(3500), config.getCleanupIntervalTimerMs());
+
+        config = with().cleanupInterval(0).build();
+        testContext.assertEquals(60, config.getCleanupInterval());
+        testContext.assertEquals(add500ms(30000), config.getCleanupIntervalTimerMs());
+
+        config = with().cleanupInterval(-5).build();
+        testContext.assertEquals(60, config.getCleanupInterval());
+        testContext.assertEquals(add500ms(30000), config.getCleanupIntervalTimerMs());
+
+        config = with().cleanupInterval(60).build();
+        testContext.assertEquals(60, config.getCleanupInterval());
+        testContext.assertEquals(add500ms(30000), config.getCleanupIntervalTimerMs());
+
+        JsonObject json = new JsonObject();
+        json.put(PROP_CLEANUP_INTERVAL, 5);
+        config = fromJsonObject(json);
+        testContext.assertEquals(5, config.getCleanupInterval());
+        testContext.assertEquals(add500ms(2500), config.getCleanupIntervalTimerMs());
+    }
+
+    private int add500ms(int interval){
+        return interval + 500;
+    }
 }


### PR DESCRIPTION
Please review and eventually merge

Tests: https://drone.io/github.com/mcweba/vertx-redisques/4

**Why lua?**
Redis provides additonal options for the **set** command. These options are available in _io.vertx.redis.RedisClient_ but the handler for the return value is a **Handler\<AsyncResult\<Void\>\>**. So the needed information cannot be accessed. This problem will be fixed with vert.x version 3.3.0. 
I made another issue to replace the lua implementation with the RedisClient method. See #15 