### PR TITLE
Do not notify consumers with locked queues #18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,11 +62,13 @@ dependencies {
 }
 
 ext.uploadToMavenCentral = false
-ext.upload = false
+  ext.InstallOrUpload = false
 gradle.taskGraph.whenReady { taskGraph ->
+    if (taskGraph.hasTask(uploadArchives) || taskGraph.hasTask(install)) {
+        ext.InstallOrUpload = true
+    }
     if (taskGraph.hasTask(uploadArchives)) {
-        ext.upload = true
-        println "upload: true"
+        println "InstallOrUpload: true"
         if ("$uploadRepository".toLowerCase().contains("sonatype")  && "$snapshotRepository".toLowerCase().contains("sonatype")) {
             println "uploadToMavenCentral: true"
             ext.uploadToMavenCentral = true
@@ -79,7 +81,7 @@ task sourceJar(type: Jar) {
     classifier = 'sources'
     from sourceSets.main.java
 }
-sourceJar.onlyIf { upload }
+sourceJar.onlyIf { InstallOrUpload }
 
 compileJava {
     options.encoding = "UTF-8"
@@ -89,7 +91,7 @@ javadoc {
     options.encoding = "UTF-8"
     classpath = configurations.compile
 }
-javadoc.onlyIf { upload }
+javadoc.onlyIf { InstallOrUpload }
 
 task javadocJar(type: Jar) {
     description = 'Builds a javadoc jar artifact suitable for maven deployment.'
@@ -97,9 +99,9 @@ task javadocJar(type: Jar) {
     from javadoc.destinationDir
 }
 javadocJar.dependsOn javadoc
-javadocJar.onlyIf { upload }
+javadocJar.onlyIf { InstallOrUpload }
 
-build.dependsOn sourceJar, javadocJar
+  uploadArchives.dependsOn sourceJar, javadocJar
 
 artifacts {
     archives jar, sourceJar, javadocJar
@@ -153,7 +155,10 @@ uploadArchives {
                 authentication(userName: "$repoUsername", password: "$repoPassword")
             }
 
+        if(uploadToMavenCentral) {
             beforeDeployment { org.gradle.api.artifacts.maven.MavenDeployment deployment -> signing.signPom(deployment) }
+        }
+
 
             configurePom(pom)
         }

--- a/src/test/java/org/swisspush/redisques/AbstractTestCase.java
+++ b/src/test/java/org/swisspush/redisques/AbstractTestCase.java
@@ -5,7 +5,6 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.Message;
-import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -30,18 +29,6 @@ public abstract class AbstractTestCase {
     protected static Jedis jedis;
 
     protected static String deploymentId = "";
-
-    private MessageConsumer<JsonObject> processorAddressConsumer;
-
-    protected void setProcessorAddressConsumer(MessageConsumer<JsonObject> processorAddressConsumer) {
-        this.processorAddressConsumer = processorAddressConsumer;
-    }
-
-    protected void unregisterProcessorAddressConsumer(){
-        if(processorAddressConsumer != null) {
-            processorAddressConsumer.unregister();
-        }
-    }
 
     protected void flushAll(){
         if(jedis != null){

--- a/src/test/java/org/swisspush/redisques/RedisQuesTest.java
+++ b/src/test/java/org/swisspush/redisques/RedisQuesTest.java
@@ -1,30 +1,21 @@
 package org.swisspush.redisques;
 
-import io.vertx.core.AsyncResult;
+import com.jayway.awaitility.Awaitility;
+import com.jayway.awaitility.Duration;
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.Timeout;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.swisspush.redisques.util.RedisquesConfiguration;
 import redis.clients.jedis.Jedis;
 
-import javax.xml.bind.DatatypeConverter;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
-
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.swisspush.redisques.util.RedisquesAPI.*;
 
 /**
@@ -37,16 +28,17 @@ public class RedisQuesTest extends AbstractTestCase {
     public static final String TIMESTAMP = "timestamp";
     public static final String QUEUES_PREFIX = "redisques:queues:";
     public static final String REDISQUES_LOCKS = "redisques:locks";
+    public static final String PROCESSOR_ADDRESS = "processor-address";
 
     @Rule
-    public Timeout rule = Timeout.seconds(5);
+    public Timeout rule = Timeout.seconds(10);
 
     @BeforeClass
     public static void deployRedisques(TestContext context) {
         vertx = Vertx.vertx();
 
         JsonObject config = RedisquesConfiguration.with()
-                .processorAddress("processor-address")
+                .processorAddress(PROCESSOR_ADDRESS)
                 .redisEncoding("ISO-8859-1")
                 .refreshPeriod(2)
                 .build()
@@ -402,6 +394,50 @@ public class RedisQuesTest extends AbstractTestCase {
             context.assertFalse(jedis.hexists(REDISQUES_LOCKS, "notExistingLock"));
             async.complete();
         });
+    }
+
+    @Test
+    public void queueProcessorShouldNotBeNotNotifiedWithLockedQueue(TestContext context) throws Exception {
+        Async async = context.async();
+        flushAll();
+
+        String queue = "queue1";
+        final boolean[] processorCalled = {false};
+
+        lockQueue(queue);
+
+        setProcessorAddressConsumer(vertx.eventBus().consumer(PROCESSOR_ADDRESS, call -> processorCalled[0] = true));
+
+        eventBusSend(buildEnqueueOperation(queue, "hello"), reply -> {
+            context.assertEquals(OK, reply.result().body().getString(STATUS));
+        });
+
+        // after at most 5 seconds, the processor-address consumer should not have been called
+        Awaitility.await().atMost(Duration.FIVE_SECONDS).until(() -> processorCalled[0], equalTo(false));
+
+        unregisterProcessorAddressConsumer();
+        async.complete();
+    }
+
+    @Test
+    public void queueProcessorShouldBeNotifiedWithNonLockedQueue(TestContext context) throws Exception {
+        Async async = context.async();
+        flushAll();
+
+        String queue = "queue1";
+        final boolean[] processorCalled = {false};
+
+        setProcessorAddressConsumer(vertx.eventBus().consumer(PROCESSOR_ADDRESS, call -> processorCalled[0] = true));
+
+        eventBusSend(buildEnqueueOperation(queue, "hello"), reply -> {
+            context.assertEquals(OK, reply.result().body().getString(STATUS));
+        });
+
+        // after at most 5 seconds, the processor-address consumer should have been called
+        Awaitility.await().atMost(Duration.FIVE_SECONDS).until(() -> processorCalled[0], equalTo(true));
+
+        unregisterProcessorAddressConsumer();
+        async.complete();
     }
 
     @Test

--- a/src/test/java/org/swisspush/redisques/RedisQuesTest.java
+++ b/src/test/java/org/swisspush/redisques/RedisQuesTest.java
@@ -1,7 +1,5 @@
 package org.swisspush.redisques;
 
-import com.jayway.awaitility.Awaitility;
-import com.jayway.awaitility.Duration;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
@@ -15,7 +13,6 @@ import org.junit.Test;
 import org.swisspush.redisques.util.RedisquesConfiguration;
 import redis.clients.jedis.Jedis;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.swisspush.redisques.util.RedisquesAPI.*;
 
 /**
@@ -394,50 +391,6 @@ public class RedisQuesTest extends AbstractTestCase {
             context.assertFalse(jedis.hexists(REDISQUES_LOCKS, "notExistingLock"));
             async.complete();
         });
-    }
-
-    @Test
-    public void queueProcessorShouldNotBeNotNotifiedWithLockedQueue(TestContext context) throws Exception {
-        Async async = context.async();
-        flushAll();
-
-        String queue = "queue1";
-        final boolean[] processorCalled = {false};
-
-        lockQueue(queue);
-
-        setProcessorAddressConsumer(vertx.eventBus().consumer(PROCESSOR_ADDRESS, call -> processorCalled[0] = true));
-
-        eventBusSend(buildEnqueueOperation(queue, "hello"), reply -> {
-            context.assertEquals(OK, reply.result().body().getString(STATUS));
-        });
-
-        // after at most 5 seconds, the processor-address consumer should not have been called
-        Awaitility.await().atMost(Duration.FIVE_SECONDS).until(() -> processorCalled[0], equalTo(false));
-
-        unregisterProcessorAddressConsumer();
-        async.complete();
-    }
-
-    @Test
-    public void queueProcessorShouldBeNotifiedWithNonLockedQueue(TestContext context) throws Exception {
-        Async async = context.async();
-        flushAll();
-
-        String queue = "queue1";
-        final boolean[] processorCalled = {false};
-
-        setProcessorAddressConsumer(vertx.eventBus().consumer(PROCESSOR_ADDRESS, call -> processorCalled[0] = true));
-
-        eventBusSend(buildEnqueueOperation(queue, "hello"), reply -> {
-            context.assertEquals(OK, reply.result().body().getString(STATUS));
-        });
-
-        // after at most 5 seconds, the processor-address consumer should have been called
-        Awaitility.await().atMost(Duration.FIVE_SECONDS).until(() -> processorCalled[0], equalTo(true));
-
-        unregisterProcessorAddressConsumer();
-        async.complete();
     }
 
     @Test

--- a/src/test/java/org/swisspush/redisques/RedisQuesTest.java
+++ b/src/test/java/org/swisspush/redisques/RedisQuesTest.java
@@ -28,7 +28,7 @@ public class RedisQuesTest extends AbstractTestCase {
     public static final String PROCESSOR_ADDRESS = "processor-address";
 
     @Rule
-    public Timeout rule = Timeout.seconds(10);
+    public Timeout rule = Timeout.seconds(5);
 
     @BeforeClass
     public static void deployRedisques(TestContext context) {


### PR DESCRIPTION
Please review and eventually merge.

Tests have been successfully executed: See [https://drone.io/github.com/swisspush/vertx-redisques/56](https://drone.io/github.com/swisspush/vertx-redisques/56)

Additional tests are:

- RedisQuesProcessorTest.queueProcessorShouldBeNotifiedWithNonLockedQueue
- RedisQuesProcessorTest.queueProcessorShouldNotBeNotNotifiedWithLockedQueue