### PR TITLE
Compile against redis-client 3.4.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=org.swisspush
 name=redisques
-version=2.4.2_with_redis_client_3_4_2-SNAPSHOT
+version=2.4.2-SNAPSHOT
 
 awaitilityVersion=1.6.5
 commonscodecVersion=1.9

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=org.swisspush
 name=redisques
-version=2.4.2-SNAPSHOT
+version=2.4.2_with_redis_client_3_4_2-SNAPSHOT
 
 awaitilityVersion=1.6.5
 commonscodecVersion=1.9

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,6 @@ jedisVersion=2.4.1
 junitVersion=4.12
 restAssuredVersion=2.4.1
 toolsVersion=2.0.3-final
-vertxVersion=3.3.3
+vertxVersion=3.4.2
 
 runModArgs=-conf conf.json


### PR DESCRIPTION
Due to https://github.com/vert-x3/vertx-redis-client/issues/65 we need an up-to-date RedisClient for RedisQues (i.e. 3.4.2 which includes the fix)
Recompilation is required due to a small change in a method signature: a parameter type of`RedisClient.expire(...)` changed from `int` to `long`.
Unfortunately it's not possible to have one RedisQues which works with redis-client 3.3.3 **and** 3.4.2

A complete update of Gateleen to 3.4.2 is not possible with limited effort - but we need a quick fix.
So we decided to mix JARs: Vertx basically in version 3.3.3, only redis-client updated to 3.4.2