### PR TITLE
Vert.x's RedisClient has an unlucky behaviour at specific race condit…

### DIFF
--- a/src/main/java/org/swisspush/redisques/handler/GetAllLocksHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetAllLocksHandler.java
@@ -24,14 +24,9 @@ public class GetAllLocksHandler implements Handler<AsyncResult<JsonArray>> {
 
     @Override
     public void handle(AsyncResult<JsonArray> reply) {
-        if(reply.succeeded()){
-            List<Object> list = reply.result().getList();
+        if (reply.succeeded() && reply.result() != null) {
             JsonObject result = new JsonObject();
-            JsonArray items = new JsonArray();
-            for (Object item : list.toArray()) {
-                items.add((String) item);
-            }
-            result.put("locks", items);
+            result.put("locks", reply.result());
             event.reply(new JsonObject().put(STATUS, OK).put(VALUE, result));
         } else {
             event.reply(new JsonObject().put(STATUS, ERROR));

--- a/src/main/java/org/swisspush/redisques/handler/GetLockHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetLockHandler.java
@@ -21,10 +21,14 @@ public class GetLockHandler implements Handler<AsyncResult<String>> {
 
     @Override
     public void handle(AsyncResult<String> reply) {
-        if (reply.result() != null) {
-            event.reply(new JsonObject().put(STATUS, OK).put(VALUE, reply.result()));
+        if (reply.succeeded()) {
+            if (reply.result() != null) {
+                event.reply(new JsonObject().put(STATUS, OK).put(VALUE, reply.result()));
+            } else {
+                event.reply(new JsonObject().put(STATUS, NO_SUCH_LOCK));
+            }
         } else {
-            event.reply(new JsonObject().put(STATUS, NO_SUCH_LOCK));
+            event.reply(new JsonObject().put(STATUS, ERROR));
         }
     }
 }

--- a/src/main/java/org/swisspush/redisques/handler/GetQueueItemHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueueItemHandler.java
@@ -20,7 +20,7 @@ public class GetQueueItemHandler implements Handler<AsyncResult<String>> {
 
     @Override
     public void handle(AsyncResult<String> reply) {
-        if (reply.result() != null) {
+        if (reply.succeeded() && reply.result() != null) {
             event.reply(new JsonObject().put(STATUS, OK).put(VALUE, reply.result()));
         } else {
             event.reply(new JsonObject().put(STATUS, ERROR));

--- a/src/main/java/org/swisspush/redisques/handler/GetQueueItemsHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueueItemsHandler.java
@@ -26,7 +26,9 @@ public class GetQueueItemsHandler implements Handler<AsyncResult<JsonArray>> {
         if(reply.succeeded()){
             JsonArray resultArray = reply.result();
             JsonArray countInfo = new JsonArray();
-            countInfo.add(resultArray.size());
+            if (resultArray != null) {
+                countInfo.add(resultArray.size());
+            }
             countInfo.add(queueItemCount);
             event.reply(new JsonObject().put(STATUS, OK).put(VALUE, resultArray).put(INFO, countInfo));
         } else {

--- a/src/main/java/org/swisspush/redisques/handler/GetQueuesHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueuesHandler.java
@@ -25,13 +25,8 @@ public class GetQueuesHandler implements Handler<AsyncResult<JsonArray>> {
     @Override
     public void handle(AsyncResult<JsonArray> reply) {
         if(reply.succeeded()){
-            List<Object> list = reply.result().getList();
             JsonObject result = new JsonObject();
-            JsonArray items = new JsonArray();
-            for (Object item : list.toArray()) {
-                items.add((String) item);
-            }
-            result.put("queues", items);
+            result.put("queues", reply.result());
             event.reply(new JsonObject().put(STATUS, OK).put(VALUE, result));
         } else {
             event.reply(new JsonObject().put(STATUS, ERROR));


### PR DESCRIPTION
…ions during Redis connection problems (see https://github.com/vert-x3/vertx-redis-client/issues/93).

This happens when Exceptions occur in the callback handlers and lead to an unrecoverable situation within RedisClient.

To avoid this we harden the RedisQues's Handlers with a defensive implementation and a bunch of null-checks.