### PR TITLE
Use EventBus.consumer instead of EventBus.localConsumer due to much better performance in clustered environment.

### DIFF
--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -195,7 +195,7 @@ public class RedisQues extends AbstractVerticle {
         });
 
         // Handles operations
-        eb.localConsumer(address, (Handler<Message<JsonObject>>) event -> {
+        eb.consumer(address, (Handler<Message<JsonObject>>) event -> {
             String operation = event.body().getString(OPERATION);
             if (log.isTraceEnabled()) {
                 log.trace("RedisQues got operation:" + operation);


### PR DESCRIPTION
See also https://github.com/eclipse/vert.x/issues/2617 and https://gist.github.com/oli-h/e44c9e42033bd10945dc6c6afa460fcb

Solves #7