### PR TITLE
[#59] Stabilize RedisQues by improving error handling

### DIFF
--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -124,8 +124,8 @@ public class RedisQues extends AbstractVerticle {
     // for a queue.
     private Handler<Message<String>> registrationRequestHandler = event -> {
         final String queue = event.body();
-        if( queue == null ){
-            log.warn( "Got message without queue name. Will ignore request." );
+        if (queue == null) {
+            log.warn("Got message without queue name. Will ignore request.");
             return; // "https://softwareengineering.stackexchange.com/a/190535"
         }
         log.debug("RedisQues Got registration request for queue " + queue + " from consumer: " + uid);
@@ -305,9 +305,9 @@ public class RedisQues extends AbstractVerticle {
         // Handles notifications
         uidMessageConsumer = eb.consumer(uid, event -> {
             final String queue = event.body();
-            if( null == queue ){
-                log.warn( "Ignored uid msg with empty body.  uid={}  address={}  replyAddress={}", uid, event.address() , event.replyAddress() );
-            }else{
+            if (null == queue) {
+                log.warn("Ignored uid msg with empty body.  uid={}  address={}  replyAddress={}", uid, event.address(), event.replyAddress());
+            } else {
                 log.debug("RedisQues Got notification for queue " + queue);
                 consume(queue);
             }
@@ -324,8 +324,8 @@ public class RedisQues extends AbstractVerticle {
                     log.trace("RedisQues refresh queues get: " + consumerKey);
                 }
                 redisClient.get(consumerKey, getConsumerEvent -> {
-                    if( getConsumerEvent.failed() ){
-                        log.warn( "Failed to get queue consumer for queue '{}'." , queue , getConsumerEvent.cause() );
+                    if (getConsumerEvent.failed()) {
+                        log.warn("Failed to get queue consumer for queue '{}'.", queue, getConsumerEvent.cause());
                         return; // "https://softwareengineering.stackexchange.com/a/190535"
                     }
                     String consumer = getConsumerEvent.result();
@@ -459,15 +459,15 @@ public class RedisQues extends AbstractVerticle {
             if (event1.succeeded()) {
                 String keyLrem = getQueuesPrefix() + event.body().getJsonObject(PAYLOAD).getString(QUEUENAME);
                 redisClient.lrem(keyLrem, 0, "TO_DELETE", replyLrem -> {
-                    if( replyLrem.succeeded() ) {
+                    if (replyLrem.succeeded()) {
                         event.reply(new JsonObject().put(STATUS, OK));
-                    }else{
-                        log.warn( "Redis 'lrem' command failed.", replyLrem.cause() );
-                        event.reply(new JsonObject().put(STATUS,ERROR));
+                    } else {
+                        log.warn("Redis 'lrem' command failed.", replyLrem.cause());
+                        event.reply(new JsonObject().put(STATUS, ERROR));
                     }
                 });
             } else {
-                log.error( "Failed to 'lset' while deleteQueueItem." , event1.cause() );
+                log.error("Failed to 'lset' while deleteQueueItem.", event1.cause());
                 event.reply(new JsonObject().put(STATUS, ERROR));
             }
         });
@@ -478,18 +478,18 @@ public class RedisQues extends AbstractVerticle {
         boolean unlock = payload.getBoolean(UNLOCK, false);
         String queue = payload.getString(QUEUENAME);
         redisClient.del(buildQueueKey(queue), deleteReply -> {
-            if( deleteReply.failed() ){
-                log.warn( "Failed to deleteAllQueueItems.", deleteReply.cause() );
+            if (deleteReply.failed()) {
+                log.warn("Failed to deleteAllQueueItems.", deleteReply.cause());
                 // I like to return here. But:
                 // We need to continue below to release lock. After lock is released, impl will
                 // respond to event with ERROR anyway.
             }
             if (unlock) {
                 redisClient.hdel(getLocksKey(), queue, unlockReply -> {
-                    if( unlockReply.failed() ){
-                        log.warn( "Failed to unlock queue '{}'." , queue , unlockReply.cause() );
-                        replyWithStatusError( event );
-                    }else{
+                    if (unlockReply.failed()) {
+                        log.warn("Failed to unlock queue '{}'.", queue, unlockReply.cause());
+                        replyWithStatusError(event);
+                    } else {
                         replyResultGreaterThanZero(event, deleteReply);
                     }
                 });
@@ -499,8 +499,8 @@ public class RedisQues extends AbstractVerticle {
         });
     }
 
-    private void replyWithStatusError(Message<?> event){
-        event.reply( "{\"status\":\"error\"}" );
+    private void replyWithStatusError(Message<?> event) {
+        event.reply("{\"status\":\"error\"}");
     }
 
     int updateQueueFailureCountAndGetRetryInterval(String queue, boolean sendSuccess) {
@@ -837,8 +837,8 @@ public class RedisQues extends AbstractVerticle {
                         log.trace("RedisQues unregister consumers get: " + consumerKey);
                     }
                     redisClient.get(consumerKey, event1 -> {
-                        if( event1.failed() ){
-                            log.error( "Failed to retrieve consumer '{}'.", consumerKey, event1.cause() );
+                        if (event1.failed()) {
+                            log.error("Failed to retrieve consumer '{}'.", consumerKey, event1.cause());
                             return; // "https://softwareengineering.stackexchange.com/a/190535"
                         }
                         String consumer = event1.result();
@@ -889,8 +889,8 @@ public class RedisQues extends AbstractVerticle {
     private void consume(final String queue) {
         log.debug(" RedisQues Requested to consume queue " + queue);
         refreshRegistration(queue, event -> {
-            if( event.failed() ){
-                log.error( "Failed to refresh registration for queue '{}'." , queue , event.cause() );
+            if (event.failed()) {
+                log.error("Failed to refresh registration for queue '{}'.", queue, event.cause());
                 return; // "https://softwareengineering.stackexchange.com/a/190535"
             }
             // Make sure that I am still the registered consumer
@@ -942,7 +942,7 @@ public class RedisQues extends AbstractVerticle {
         Future<Boolean> future = Future.future();
         redisClient.hexists(getLocksKey(), queue, event -> {
             if (event.failed() || event.result() == null) {
-                log.warn("Failed to check if queue '{}' is locked.", queue , event.cause() );
+                log.warn("Failed to check if queue '{}' is locked.", queue, event.cause());
                 // TODO:  Is it correct, to assume a queue is not locked in case our query failed?
                 future.complete(Boolean.FALSE);
             } else {
@@ -967,8 +967,8 @@ public class RedisQues extends AbstractVerticle {
             boolean locked = lockAnswer.result();
             if (!locked) {
                 redisClient.lindex(key, 0, answer -> {
-                    if( answer.failed() ){
-                        log.error( "Failed to peek queue '{}'" , queue , answer.cause() );
+                    if (answer.failed()) {
+                        log.error("Failed to peek queue '{}'", queue, answer.cause());
                         return; // "https://softwareengineering.stackexchange.com/a/190535"
                     }
                     if (log.isTraceEnabled()) {
@@ -988,8 +988,8 @@ public class RedisQues extends AbstractVerticle {
                                     log.trace("RedisQues read queue lpop: " + key1);
                                 }
                                 redisClient.lpop(key1, jsonAnswer -> {
-                                    if( jsonAnswer.failed() ){
-                                        log.warn( "Failed to pop from queue '{}'" , queue , jsonAnswer.cause() );
+                                    if (jsonAnswer.failed()) {
+                                        log.warn("Failed to pop from queue '{}'", queue, jsonAnswer.cause());
                                         return; // "https://softwareengineering.stackexchange.com/a/190535"
                                     }
                                     log.debug("RedisQues Message removed, queue " + queue + " is ready again");
@@ -1116,8 +1116,8 @@ public class RedisQues extends AbstractVerticle {
             log.trace("RedisQues notify consumer get: " + key);
         }
         redisClient.get(key, event -> {
-            if( event.failed() ){
-                log.error( "Failed to get consumer for queue '{}'" , queue , event.cause() );
+            if (event.failed()) {
+                log.error("Failed to get consumer for queue '{}'", queue, event.cause());
                 return; // "https://softwareengineering.stackexchange.com/a/190535"
             }
             String consumer = event.result();
@@ -1205,8 +1205,8 @@ public class RedisQues extends AbstractVerticle {
                         log.debug("Updating queue timestamp " + queue);
                         // If not empty, update the queue timestamp to keep it in the sorted set.
                         updateTimestamp(queue, result -> {
-                            if( result.failed() ){
-                                log.error( "Failed to update timestamps" , result.cause() );
+                            if (result.failed()) {
+                                log.error("Failed to update timestamps", result.cause());
                                 return; // "https://softwareengineering.stackexchange.com/a/190535"
                             }
                             // Ensure we clean the old queues after having updated all timestamps

--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -125,9 +125,8 @@ public class RedisQues extends AbstractVerticle {
     private Handler<Message<String>> registrationRequestHandler = event -> {
         final String queue = event.body();
         if (queue == null) {
-            log.warn("Got message without queue name. Will ignore request.");
-            event.reply( newErrorReplyBodyMissing() );
-            return;
+            log.warn("Got message without queue name. _2e098ed6828ff13db_");
+            // IMO we should 'fail()' here. But we don't, to keep backward compatibility.
         }
         log.debug("RedisQues Got registration request for queue " + queue + " from consumer: " + uid);
         // Try to register for this queue
@@ -203,11 +202,8 @@ public class RedisQues extends AbstractVerticle {
         eb.consumer(address, (Handler<Message<JsonObject>>) event -> {
             final JsonObject body = event.body();
             if (null == body) {
-                log.warn("Got msg with empty body from event bus. Will ignore it. address={}  replyAddress={} ", event.address(), event.replyAddress());
-                event.reply(newErrorReplyBodyMissing());
-                // There is no sense to continue below. We would run directly into
-                // NullPointerException anyway.
-                return;
+                log.warn("Got msg with empty body from event bus. We'll run directly in a NullPointerException now. address={}  replyAddress={} ", event.address(), event.replyAddress());
+                // IMO we should 'fail()' here. But we don't, to keep backward compatibility.
             }
             String operation = body.getString(OPERATION);
             if (log.isTraceEnabled()) {
@@ -308,12 +304,11 @@ public class RedisQues extends AbstractVerticle {
         uidMessageConsumer = eb.consumer(uid, event -> {
             final String queue = event.body();
             if (queue == null) {
-                log.warn("Ignored uid msg with empty body.  uid={}  address={}  replyAddress={}", uid, event.address(), event.replyAddress());
-                event.reply(newErrorReplyBodyMissing());
-            } else {
-                log.debug("RedisQues got notification for queue '{}'", queue);
-                consume(queue);
+                log.warn("Got event bus msg with empty body! _28904718b4af0cc_  uid={}  address={}  replyAddress={}", uid, event.address(), event.replyAddress());
+                // IMO we should 'fail()' here. But we don't, to keep backward compatibility.
             }
+            log.debug("RedisQues got notification for queue '{}'", queue);
+            consume(queue);
         });
 
         // Periodic refresh of my registrations on active queues.
@@ -328,8 +323,8 @@ public class RedisQues extends AbstractVerticle {
                 }
                 redisClient.get(consumerKey, getConsumerEvent -> {
                     if (getConsumerEvent.failed()) {
-                        log.warn("Failed to get queue consumer for queue '{}'.", queue, getConsumerEvent.cause());
-                        return;
+                        log.warn("Failed to get queue consumer for queue '{}'. But we'll continue anyway :)", queue, getConsumerEvent.cause());
+                        // We should return here. See: "https://softwareengineering.stackexchange.com/a/190535"
                     }
                     final String consumer = getConsumerEvent.result();
                     if (uid.equals(consumer)) {
@@ -404,8 +399,8 @@ public class RedisQues extends AbstractVerticle {
             if (countReply.succeeded() && queueItemCount != null) {
                 redisClient.lrange(keyListRange, 0, maxQueueItemCountIndex, new GetQueueItemsHandler(event, queueItemCount));
             } else {
-                log.warn("Operation getQueueItems failed", countReply.cause());
-                event.reply(newErrorReply());
+                log.warn("Operation getQueueItems failed. But I'll not notify my caller :) _5e51764bf36c19a781_", countReply.cause());
+                // IMO we should 'event.fail(countReply.cause())' here. But we don't, to keep backward compatibility.
             }
         });
     }
@@ -461,16 +456,15 @@ public class RedisQues extends AbstractVerticle {
             if (event1.succeeded()) {
                 String keyLrem = getQueuesPrefix() + event.body().getJsonObject(PAYLOAD).getString(QUEUENAME);
                 redisClient.lrem(keyLrem, 0, "TO_DELETE", replyLrem -> {
-                    if (replyLrem.succeeded()) {
-                        event.reply(newOkReply());
-                    } else {
-                        log.warn("Redis 'lrem' command failed.", replyLrem.cause());
-                        event.reply(newErrorReply());
+                    if (replyLrem.failed()) {
+                        log.warn("Redis 'lrem' command failed. But will continue anyway _bba106b17e21cc_.", replyLrem.cause());
+                        // IMO we should 'fail()' here. But we don't, to keep backward compatibility.
                     }
+                    event.reply(createOkReply());
                 });
             } else {
                 log.error("Failed to 'lset' while deleteQueueItem.", event1.cause());
-                event.reply(newErrorReply());
+                event.reply(createErrorReply());
             }
         });
     }
@@ -481,18 +475,18 @@ public class RedisQues extends AbstractVerticle {
         String queue = payload.getString(QUEUENAME);
         redisClient.del(buildQueueKey(queue), deleteReply -> {
             if (deleteReply.failed()) {
-                log.warn("Failed to deleteAllQueueItems.", deleteReply.cause());
-                // I like to return here. But: We need to continue below to may release lock.
-                // After lock is released, impl will respond to event with ERROR anyway.
+                log.warn("Failed to deleteAllQueueItems. But we'll continue anyway. _dfc641c96464_", deleteReply.cause());
+                // May we should 'fail()' here. But:
+                // 1st: We don't, to keep backward compatibility
+                // 2nd: We don't, to may unlock below.
             }
             if (unlock) {
                 redisClient.hdel(getLocksKey(), queue, unlockReply -> {
                     if (unlockReply.failed()) {
-                        log.warn("Failed to unlock queue '{}'.", queue, unlockReply.cause());
-                        event.reply(newErrorReply());
-                    } else {
-                        replyResultGreaterThanZero(event, deleteReply);
+                        log.warn("Failed to unlock queue '{}'. Will continue anyway _d08ae0e0986587_.", queue, unlockReply.cause());
+                        // IMO we should 'fail()' here. But we don't, to keep backward compatibility.
                     }
+                    replyResultGreaterThanZero(event, deleteReply);
                 });
             } else {
                 replyResultGreaterThanZero(event, deleteReply);
@@ -835,8 +829,8 @@ public class RedisQues extends AbstractVerticle {
                     }
                     redisClient.get(consumerKey, event1 -> {
                         if (event1.failed()) {
-                            log.error("Failed to retrieve consumer '{}'.", consumerKey, event1.cause());
-                            return;
+                            log.warn("Failed to retrieve consumer '{}'.", consumerKey, event1.cause());
+                            // IMO we should 'fail()' here. But we don't, to keep backward compatibility.
                         }
                         String consumer = event1.result();
                         if (log.isTraceEnabled()) {
@@ -887,8 +881,8 @@ public class RedisQues extends AbstractVerticle {
         log.debug(" RedisQues Requested to consume queue " + queue);
         refreshRegistration(queue, event -> {
             if (event.failed()) {
-                log.error("Failed to refresh registration for queue '{}'.", queue, event.cause());
-                return;
+                log.warn("Failed to refresh registration for queue '{}'.", queue, event.cause());
+                // We should return here. See: "https://softwareengineering.stackexchange.com/a/190535"
             }
             // Make sure that I am still the registered consumer
             String key = getConsumersPrefix() + queue;
@@ -937,8 +931,12 @@ public class RedisQues extends AbstractVerticle {
     private Future<Boolean> isQueueLocked(final String queue) {
         Future<Boolean> future = Future.future();
         redisClient.hexists(getLocksKey(), queue, event -> {
-            if (event.failed() || event.result() == null) {
-                log.warn("failed to check if queue '" + queue + "' is locked. Message: " + event.cause().getMessage());
+            if (event.failed()) {
+                log.warn("Failed to check if queue '{}' is locked. Assume no.", queue, event.cause());
+                // TODO:  Is it correct, to assume a queue is not locked in case our query failed?
+                // Previous implementation assumed this. See "https://github.com/hiddenalpha/vertx-redisques/blob/v2.5.1/src/main/java/org/swisspush/redisques/RedisQues.java#L856".
+                future.complete(Boolean.FALSE);
+            } else if (event.result() == null) {
                 future.complete(Boolean.FALSE);
             } else {
                 future.complete(event.result() == 1);
@@ -959,14 +957,14 @@ public class RedisQues extends AbstractVerticle {
         isQueueLocked(queue).setHandler(lockAnswer -> {
             if (lockAnswer.failed()) {
                 log.error("Failed to check if queue '{}' is locked", queue, lockAnswer.cause());
-                return;
+                // We should return here. See: "https://softwareengineering.stackexchange.com/a/190535"
             }
             boolean locked = lockAnswer.result();
             if (!locked) {
                 redisClient.lindex(key, 0, answer -> {
                     if (answer.failed()) {
                         log.error("Failed to peek queue '{}'", queue, answer.cause());
-                        return;
+                        // We should return here. See: "https://softwareengineering.stackexchange.com/a/190535"
                     }
                     if (log.isTraceEnabled()) {
                         log.trace("RedisQues read queue lindex result: " + answer.result());
@@ -987,7 +985,7 @@ public class RedisQues extends AbstractVerticle {
                                 redisClient.lpop(key1, jsonAnswer -> {
                                     if (jsonAnswer.failed()) {
                                         log.error("Failed to pop from queue '{}'", queue, jsonAnswer.cause());
-                                        return;
+                                        // We should return here. See: "https://softwareengineering.stackexchange.com/a/190535"
                                     }
                                     log.debug("RedisQues Message removed, queue " + queue + " is ready again");
                                     myQueues.put(queue, QueueState.READY);
@@ -1055,9 +1053,8 @@ public class RedisQues extends AbstractVerticle {
         }
         timer.executeDelayedMax(processorDelayMax).setHandler(delayed -> {
             if (delayed.failed()) {
-                log.error("Delayed execution has failed. Cause: " + delayed.cause().getMessage());
-                final SendResult event = new SendResult(false, null);
-                handler.handle(event);
+                log.error("Delayed execution has failed.", delayed.cause());
+                // TODO: May we should call handler with failed state now.
                 return;
             }
             final EventBus eb = vertx.eventBus();
@@ -1109,8 +1106,8 @@ public class RedisQues extends AbstractVerticle {
         }
         redisClient.get(key, event -> {
             if (event.failed()) {
-                log.error("Failed to get consumer for queue '{}'", queue, event.cause());
-                return;
+                log.warn("Failed to get consumer for queue '{}'", queue, event.cause());
+                // We should return here. See: "https://softwareengineering.stackexchange.com/a/190535"
             }
             String consumer = event.result();
             if (log.isTraceEnabled()) {
@@ -1194,12 +1191,12 @@ public class RedisQues extends AbstractVerticle {
                         return;
                     }
                     if (event.result() == 1) {
-                        log.debug("Updating queue timestamp " + queue);
+                        log.debug("Updating queue timestamp for queue '{}'", queue);
                         // If not empty, update the queue timestamp to keep it in the sorted set.
                         updateTimestamp(queue, result -> {
                             if (result.failed()) {
-                                log.error("Failed to update timestamps for queue '{}'", queue, result.cause());
-                                return;
+                                log.warn("Failed to update timestamps for queue '{}'", queue, result.cause());
+                                // We should return here. See: "https://softwareengineering.stackexchange.com/a/190535"
                             }
                             // Ensure we clean the old queues after having updated all timestamps
                             if (counter.decrementAndGet() == 0) {
@@ -1224,16 +1221,12 @@ public class RedisQues extends AbstractVerticle {
         });
     }
 
-    private static JsonObject newOkReply() {
+    private static JsonObject createOkReply() {
         return new JsonObject().put(STATUS, OK);
     }
 
-    private static JsonObject newErrorReply() {
+    private static JsonObject createErrorReply() {
         return new JsonObject().put(STATUS, ERROR);
-    }
-
-    private static JsonObject newErrorReplyBodyMissing() {
-        return new JsonObject().put(STATUS,ERROR).put(MESSAGE,"Message body missing");
     }
 
     /**

--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -34,10 +34,6 @@ public class RedisQues extends AbstractVerticle {
         READY, CONSUMING
     }
 
-    private static final String REPLY_OK = new JsonObject().put(STATUS, OK).toString();
-    private static final String REPLY_ERROR = new JsonObject().put(STATUS, ERROR).toString();
-    private static final String REPLY_ERROR_BODY_MISSING = new JsonObject().put(STATUS,ERROR).put(MESSAGE,"Message body missing").toString();
-
     // Identifies the consumer
     private String uid = UUID.randomUUID().toString();
 
@@ -130,7 +126,7 @@ public class RedisQues extends AbstractVerticle {
         final String queue = event.body();
         if (queue == null) {
             log.warn("Got message without queue name. Will ignore request.");
-            event.reply(REPLY_ERROR_BODY_MISSING);
+            event.reply( newErrorReplyBodyMissing() );
             return;
         }
         log.debug("RedisQues Got registration request for queue " + queue + " from consumer: " + uid);
@@ -208,7 +204,7 @@ public class RedisQues extends AbstractVerticle {
             final JsonObject body = event.body();
             if (null == body) {
                 log.warn("Got msg with empty body from event bus. Will ignore it. address={}  replyAddress={} ", event.address(), event.replyAddress());
-                event.reply(REPLY_ERROR_BODY_MISSING);
+                event.reply(newErrorReplyBodyMissing());
                 // There is no sense to continue below. We would run directly into
                 // NullPointerException anyway.
                 return;
@@ -313,7 +309,7 @@ public class RedisQues extends AbstractVerticle {
             final String queue = event.body();
             if (queue == null) {
                 log.warn("Ignored uid msg with empty body.  uid={}  address={}  replyAddress={}", uid, event.address(), event.replyAddress());
-                event.reply(REPLY_ERROR_BODY_MISSING);
+                event.reply(newErrorReplyBodyMissing());
             } else {
                 log.debug("RedisQues got notification for queue '{}'", queue);
                 consume(queue);
@@ -409,7 +405,7 @@ public class RedisQues extends AbstractVerticle {
                 redisClient.lrange(keyListRange, 0, maxQueueItemCountIndex, new GetQueueItemsHandler(event, queueItemCount));
             } else {
                 log.warn("Operation getQueueItems failed", countReply.cause());
-                event.reply(REPLY_ERROR);
+                event.reply(newErrorReply());
             }
         });
     }
@@ -466,15 +462,15 @@ public class RedisQues extends AbstractVerticle {
                 String keyLrem = getQueuesPrefix() + event.body().getJsonObject(PAYLOAD).getString(QUEUENAME);
                 redisClient.lrem(keyLrem, 0, "TO_DELETE", replyLrem -> {
                     if (replyLrem.succeeded()) {
-                        event.reply(REPLY_OK);
+                        event.reply(newOkReply());
                     } else {
                         log.warn("Redis 'lrem' command failed.", replyLrem.cause());
-                        event.reply(REPLY_ERROR);
+                        event.reply(newErrorReply());
                     }
                 });
             } else {
                 log.error("Failed to 'lset' while deleteQueueItem.", event1.cause());
-                event.reply(REPLY_ERROR);
+                event.reply(newErrorReply());
             }
         });
     }
@@ -493,7 +489,7 @@ public class RedisQues extends AbstractVerticle {
                 redisClient.hdel(getLocksKey(), queue, unlockReply -> {
                     if (unlockReply.failed()) {
                         log.warn("Failed to unlock queue '{}'.", queue, unlockReply.cause());
-                        event.reply(REPLY_ERROR);
+                        event.reply(newErrorReply());
                     } else {
                         replyResultGreaterThanZero(event, deleteReply);
                     }
@@ -1226,6 +1222,18 @@ public class RedisQues extends AbstractVerticle {
                 });
             }
         });
+    }
+
+    private static JsonObject newOkReply() {
+        return new JsonObject().put(STATUS, OK);
+    }
+
+    private static JsonObject newErrorReply() {
+        return new JsonObject().put(STATUS, ERROR);
+    }
+
+    private static JsonObject newErrorReplyBodyMissing() {
+        return new JsonObject().put(STATUS,ERROR).put(MESSAGE,"Message body missing");
     }
 
     /**

--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -202,7 +202,7 @@ public class RedisQues extends AbstractVerticle {
         eb.consumer(address, (Handler<Message<JsonObject>>) event -> {
             final JsonObject body = event.body();
             if (null == body) {
-                log.warn("Got msg with empty body from ev bus. Will ignore it. address={}  replyAddress={} ", event.address(), event.replyAddress());
+                log.warn("Got msg with empty body from event bus. Will ignore it. address={}  replyAddress={} ", event.address(), event.replyAddress());
                 // There is no sense to continue below. We would run directly into
                 // NullPointerException anyway.
                 return;
@@ -308,7 +308,7 @@ public class RedisQues extends AbstractVerticle {
             if (queue == null) {
                 log.warn("Ignored uid msg with empty body.  uid={}  address={}  replyAddress={}", uid, event.address(), event.replyAddress());
             } else {
-                log.debug("RedisQues Got notification for queue '{}'", queue);
+                log.debug("RedisQues got notification for queue '{}'", queue);
                 consume(queue);
             }
         });

--- a/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
@@ -210,10 +210,10 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
                 String strBuffer = encodePayload(buffer.toString());
                 eventBus.send(redisquesAddress, buildEnqueueOrLockedEnqueueOperation(queue, strBuffer, ctx.request()),
                         (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
-                            if( reply.failed() ){
-                                log.error( "Received failed message for enqueueOrLockedEnqueue." , reply.cause() );
-                                respondWith( StatusCode.INTERNAL_SERVER_ERROR , ctx.request() );
-                            }else{
+                            if (reply.failed()) {
+                                log.error("Received failed message for enqueueOrLockedEnqueue.", reply.cause());
+                                respondWith(StatusCode.INTERNAL_SERVER_ERROR, ctx.request());
+                            } else {
                                 checkReply(reply.result(), ctx.request(), StatusCode.BAD_REQUEST);
                             }
                         });
@@ -234,15 +234,15 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
     private void getAllLocks(RoutingContext ctx) {
         String filter = ctx.request().params().get(FILTER);
         eventBus.send(redisquesAddress, buildGetAllLocksOperation(Optional.ofNullable(filter)), (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
-            if( reply.failed() ){
-                log.error( "Received failed message for getAllLocksOperation." , reply.cause() );
-                respondWith( StatusCode.INTERNAL_SERVER_ERROR , ctx.request() );
-            }else if (OK.equals(reply.result().body().getString(STATUS))) {
+            if (reply.failed()) {
+                log.error("Received failed message for getAllLocksOperation.", reply.cause());
+                respondWith(StatusCode.INTERNAL_SERVER_ERROR, ctx.request());
+            } else if (OK.equals(reply.result().body().getString(STATUS))) {
                 jsonResponse(ctx.response(), reply.result().body().getJsonObject(VALUE));
             } else {
                 final JsonObject body = reply.result().body();
                 String errorType = body.getString(ERROR_TYPE);
-                if( BAD_INPUT.equalsIgnoreCase(errorType) ){
+                if (BAD_INPUT.equalsIgnoreCase(errorType)) {
                     if (body.getString(MESSAGE) != null) {
                         respondWith(StatusCode.BAD_REQUEST, reply.result().body().getString(MESSAGE), ctx.request());
                     } else {
@@ -259,10 +259,10 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
         String queue = lastPart(ctx.request().path());
         eventBus.send(redisquesAddress, buildPutLockOperation(queue, extractUser(ctx.request())),
                 (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
-                    if( reply.failed() ){
-                        log.error( "Received failed message for addLockOperation." , reply.cause() );
-                        respondWith( StatusCode.INTERNAL_SERVER_ERROR , ctx.request() );
-                    }else{
+                    if (reply.failed()) {
+                        log.error("Received failed message for addLockOperation.", reply.cause());
+                        respondWith(StatusCode.INTERNAL_SERVER_ERROR, ctx.request());
+                    } else {
                         checkReply(reply.result(), ctx.request(), StatusCode.BAD_REQUEST);
                     }
                 });
@@ -271,10 +271,10 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
     private void getSingleLock(RoutingContext ctx) {
         String queue = lastPart(ctx.request().path());
         eventBus.send(redisquesAddress, buildGetLockOperation(queue), (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
-            if( reply.failed() ){
-                log.error( "Received failed message for getSingleLockOperation." , reply.cause() );
-                respondWith( StatusCode.INTERNAL_SERVER_ERROR , ctx.request() );
-            }else if (OK.equals(reply.result().body().getString(STATUS))) {
+            if (reply.failed()) {
+                log.error("Received failed message for getSingleLockOperation.", reply.cause());
+                respondWith(StatusCode.INTERNAL_SERVER_ERROR, ctx.request());
+            } else if (OK.equals(reply.result().body().getString(STATUS))) {
                 ctx.response().putHeader(CONTENT_TYPE, APPLICATION_JSON);
                 ctx.response().end(reply.result().body().getString(VALUE));
             } else {
@@ -289,10 +289,10 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
         String queue = lastPart(ctx.request().path());
         eventBus.send(redisquesAddress, buildDeleteLockOperation(queue),
                 (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
-                    if( reply.failed() ){
-                        log.error( "Received failed message for deleteSingleLockOperation." , reply.cause() );
-                        respondWith( StatusCode.INTERNAL_SERVER_ERROR , ctx.request() );
-                    }else{
+                    if (reply.failed()) {
+                        log.error("Received failed message for deleteSingleLockOperation.", reply.cause());
+                        respondWith(StatusCode.INTERNAL_SERVER_ERROR, ctx.request());
+                    } else {
                         checkReply(reply.result(), ctx.request(), StatusCode.INTERNAL_SERVER_ERROR);
                     }
                 });
@@ -494,9 +494,9 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
             limitParam = ctx.request().params().get(LIMIT);
         }
         eventBus.send(redisquesAddress, buildGetQueueItemsOperation(queue, limitParam), (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
-            if( reply.failed() ){
-                log.error( "Received failed message for listQueueItemsOperation." , reply.cause() );
-                respondWith( StatusCode.INTERNAL_SERVER_ERROR , ctx.request() );
+            if (reply.failed()) {
+                log.error("Received failed message for listQueueItemsOperation.", reply.cause());
+                respondWith(StatusCode.INTERNAL_SERVER_ERROR, ctx.request());
                 return;
             }
             final JsonObject replyBody = reply.result().body();
@@ -523,10 +523,10 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
                 String strBuffer = encodePayload(buffer.toString());
                 eventBus.send(redisquesAddress, buildAddQueueItemOperation(queue, strBuffer),
                         (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
-                            if( reply.failed() ){
-                                log.error( "Received failed message for addQueueItemOperation." , reply.cause() );
-                                respondWith( StatusCode.INTERNAL_SERVER_ERROR , ctx.request() );
-                            }else{
+                            if (reply.failed()) {
+                                log.error("Received failed message for addQueueItemOperation.", reply.cause());
+                                respondWith(StatusCode.INTERNAL_SERVER_ERROR, ctx.request());
+                            } else {
                                 checkReply(reply.result(), ctx.request(), StatusCode.BAD_REQUEST);
                             }
                         });
@@ -540,9 +540,9 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
         final String queue = lastPart(ctx.request().path().substring(0, ctx.request().path().length() - 2));
         final int index = Integer.parseInt(lastPart(ctx.request().path()));
         eventBus.send(redisquesAddress, buildGetQueueItemOperation(queue, index), (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
-            if( reply.failed() ){
-                log.error( "Received failed message for getSingleQueueItemOperation." , reply.cause() );
-                respondWith( StatusCode.INTERNAL_SERVER_ERROR , ctx.request() );
+            if (reply.failed()) {
+                log.error("Received failed message for getSingleQueueItemOperation.", reply.cause());
+                respondWith(StatusCode.INTERNAL_SERVER_ERROR, ctx.request());
                 return;
             }
             final JsonObject replyBody = reply.result().body();
@@ -562,27 +562,27 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
         final HttpServerRequest request = ctx.request();
         final String queue = part(request.path(), 2);
         checkLocked(queue, request, event -> {
-            if( event.failed() ){
-                log.error( "Failed to check if queue '{}' is locked" , queue , event.cause() );
-                respondWith( StatusCode.INTERNAL_SERVER_ERROR , request);
-            }else if( !event.result() ){
-                respondWithQueueMustBeLocked( ctx.response() );
-            }else{
+            if (event.failed()) {
+                log.error("Failed to check if queue '{}' is locked", queue, event.cause());
+                respondWith(StatusCode.INTERNAL_SERVER_ERROR, request);
+            } else if (!event.result()) {
+                respondWithQueueMustBeLocked(ctx.response());
+            } else {
                 final int index = Integer.parseInt(lastPart(request.path()));
                 request.bodyHandler(buffer -> {
                     try {
                         String strBuffer = encodePayload(buffer.toString());
                         eventBus.send(redisquesAddress, buildReplaceQueueItemOperation(queue, index, strBuffer),
                                 (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
-                                    if( reply.failed() ){
-                                        log.error( "Received failed message for replaceSingleQueueItemOperation." , reply.cause() );
-                                        respondWith( StatusCode.INTERNAL_SERVER_ERROR , request );
-                                    }else{
+                                    if (reply.failed()) {
+                                        log.error("Received failed message for replaceSingleQueueItemOperation.", reply.cause());
+                                        respondWith(StatusCode.INTERNAL_SERVER_ERROR, request);
+                                    } else {
                                         checkReply(reply.result(), request, StatusCode.NOT_FOUND);
                                     }
                                 });
                     } catch (Exception ex) {
-                        log.warn( "Undocumented exception caught while replaceSingleQueueItem.", ex );
+                        log.warn("Undocumented exception caught while replaceSingleQueueItem.", ex);
                         respondWith(StatusCode.BAD_REQUEST, ex.getMessage(), request);
                     }
                 });
@@ -595,19 +595,19 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
         final String queue = part(request.path(), 2);
         final int index = Integer.parseInt(lastPart(request.path()));
         checkLocked(queue, request, event -> {
-            if( event.failed() ){
-                log.error( "Failed to query if queue '{}' is locked" , queue , event.cause() );
-                respondWith( StatusCode.INTERNAL_SERVER_ERROR , request);
-            }else if( !event.result() ){
+            if (event.failed()) {
+                log.error("Failed to query if queue '{}' is locked", queue, event.cause());
+                respondWith(StatusCode.INTERNAL_SERVER_ERROR, request);
+            } else if (!event.result()) {
                 // Queue not locked
-                respondWithQueueMustBeLocked( ctx.response() );
-            }else{
+                respondWithQueueMustBeLocked(ctx.response());
+            } else {
                 // Queue is locked. Go on.
                 eventBus.send(redisquesAddress, buildDeleteQueueItemOperation(queue, index),
                         (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
-                            if( reply.failed() ){
-                                log.error( "Received failed message for deleteQueueItemOperation." , reply.cause() );
-                                respondWith( StatusCode.INTERNAL_SERVER_ERROR , request);
+                            if (reply.failed()) {
+                                log.error("Received failed message for deleteQueueItemOperation.", reply.cause());
+                                respondWith(StatusCode.INTERNAL_SERVER_ERROR, request);
                             }
                             checkReply(reply.result(), request, StatusCode.NOT_FOUND);
                         });
@@ -620,10 +620,10 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
         boolean unlock = evaluateUrlParameterToBeEmptyOrTrue(UNLOCK_PARAM, request);
         final String queue = lastPart(request.path());
         eventBus.send(redisquesAddress, buildDeleteAllQueueItemsOperation(queue, unlock), reply -> {
-            if( reply.failed() ){
-                log.error( "Received failed message for deleteAllQueueItemsOperation." , reply.cause() );
-                respondWith( StatusCode.INTERNAL_SERVER_ERROR , request );
-            }else{
+            if (reply.failed()) {
+                log.error("Received failed message for deleteAllQueueItemsOperation.", reply.cause());
+                respondWith(StatusCode.INTERNAL_SERVER_ERROR, request);
+            } else {
                 ctx.response().end();
             }
         });
@@ -640,9 +640,9 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
                         return;
                     }
                     eventBus.send(redisquesAddress, buildBulkDeleteQueuesOperation(result.getOk()), (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
-                        if( reply.failed() ){
-                            log.error( "Failed to bulkDeleteQueues." , reply.cause() );
-                            respondWith( StatusCode.INTERNAL_SERVER_ERROR , request );
+                        if (reply.failed()) {
+                            log.error("Failed to bulkDeleteQueues.", reply.cause());
+                            respondWith(StatusCode.INTERNAL_SERVER_ERROR, request);
                             return; // "https://softwareengineering.stackexchange.com/a/190535"
                         }
                         final JsonObject body = reply.result().body();
@@ -713,18 +713,18 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
         eventBus.send(redisquesAddress, buildGetLockOperation(queue), (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
             final Future<Boolean> result;
             request.resume();
-            if( reply.failed() ){
-                result = Future.failedFuture( reply.cause() );
-            }else if( NO_SUCH_LOCK.equals(reply.result().body().getString(STATUS)) ){
-                result = Future.succeededFuture( false );
-            }else{
-                result = Future.succeededFuture( true );
+            if (reply.failed()) {
+                result = Future.failedFuture(reply.cause());
+            } else if (NO_SUCH_LOCK.equals(reply.result().body().getString(STATUS))) {
+                result = Future.succeededFuture(false);
+            } else {
+                result = Future.succeededFuture(true);
             }
-            handler.handle( result );
+            handler.handle(result);
         });
     }
 
-    private void respondWithQueueMustBeLocked(HttpServerResponse response ){
+    private void respondWithQueueMustBeLocked(HttpServerResponse response) {
         final String msg = "Queue must be locked to perform this operation";
         response.setStatusCode(StatusCode.CONFLICT.getStatusCode());
         response.setStatusMessage(msg);

--- a/src/main/java/org/swisspush/redisques/lua/LuaScriptState.java
+++ b/src/main/java/org/swisspush/redisques/lua/LuaScriptState.java
@@ -93,8 +93,8 @@ public class LuaScriptState {
             } else {
                 log.info("load lua script for script type: " + luaScriptType);
                 redisClient.scriptLoad(script, stringAsyncResult -> {
-                    if( stringAsyncResult.failed() ){
-                        log.error( "Received failed message for loadLuaScript." , stringAsyncResult.cause() );
+                    if (stringAsyncResult.failed()) {
+                        log.error("Received failed message for loadLuaScript.", stringAsyncResult.cause());
                         return; // "https://softwareengineering.stackexchange.com/a/190535"
                     }
                     String newSha = stringAsyncResult.result();

--- a/src/main/java/org/swisspush/redisques/lua/LuaScriptState.java
+++ b/src/main/java/org/swisspush/redisques/lua/LuaScriptState.java
@@ -93,6 +93,10 @@ public class LuaScriptState {
             } else {
                 log.info("load lua script for script type: " + luaScriptType);
                 redisClient.scriptLoad(script, stringAsyncResult -> {
+                    if( stringAsyncResult.failed() ){
+                        log.error( "Received failed message for loadLuaScript." , stringAsyncResult.cause() );
+                        return; // "https://softwareengineering.stackexchange.com/a/190535"
+                    }
                     String newSha = stringAsyncResult.result();
                     log.info("got sha from redis for lua script: " + luaScriptType + ": " + newSha);
                     if(!newSha.equals(sha)) {

--- a/src/main/java/org/swisspush/redisques/lua/LuaScriptState.java
+++ b/src/main/java/org/swisspush/redisques/lua/LuaScriptState.java
@@ -94,8 +94,8 @@ public class LuaScriptState {
                 log.info("load lua script for script type: " + luaScriptType);
                 redisClient.scriptLoad(script, stringAsyncResult -> {
                     if (stringAsyncResult.failed()) {
-                        log.error("Received failed message for loadLuaScript.", stringAsyncResult.cause());
-                        return; // "https://softwareengineering.stackexchange.com/a/190535"
+                        log.warn("Received failed message for loadLuaScript. Lets run into NullPointerException now.", stringAsyncResult.cause());
+                        // IMO we should respond with 'HTTP 5xx'. But we don't, to keep backward compatibility.
                     }
                     String newSha = stringAsyncResult.result();
                     log.info("got sha from redis for lua script: " + luaScriptType + ": " + newSha);


### PR DESCRIPTION
- Add error handling for asynchronous operations.
- Add missing 'break' in switch statement.
- Dropped useless null checks.
- Eliminated some repeated getter calls.