### PR TITLE
Use DeliveryOption instead of a timer to detect timeouts on the EventBus

### DIFF
--- a/src/test/java/org/swisspush/redisques/RedisQuesProcessorTest.java
+++ b/src/test/java/org/swisspush/redisques/RedisQuesProcessorTest.java
@@ -70,6 +70,7 @@ public class RedisQuesProcessorTest extends AbstractTestCase {
                 .processorAddress("processor-address")
                 .redisEncoding("ISO-8859-1")
                 .refreshPeriod(2)
+                .processorTimeout(10)
                 .build()
                 .asJsonObject();
 


### PR DESCRIPTION
- get rid of this RedisQues internal 'delivery timeout' timer
- use Vertx' DeliveryOption when sending the message to the Consumer (QueueProcessor) and set the processorTimeout value (240 seconds) 

This simplifies the code and effectively enables delivery timeouts > 30 seconds

Solves #66