### PR TITLE
New feature "Enqueue-Slowdown" (or -Throttling)

### DIFF
--- a/src/main/java/org/swisspush/redisques/util/QueueConfiguration.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueConfiguration.java
@@ -2,34 +2,64 @@ package org.swisspush.redisques.util;
 
 import io.vertx.core.json.JsonObject;
 
-import java.util.List;
+import java.util.Arrays;
+import java.util.regex.Pattern;
 
 public class QueueConfiguration {
-    
-    static final String PROP_PATTERN = "pattern";
-    static final String PROP_RETRY_INTERVALS = "retryIntervals";
-    
-    private String pattern;
-    
-    private List<Integer> retryIntervals;
 
-    @SuppressWarnings("unused")
-    public QueueConfiguration() {
-        // required to be deserialized by io.vertx.core.json.JsonObject.mapTo(type)
-    }
+    /**
+     * This configuration applies to queues with names matching this RegEx
+     */
+    private Pattern pattern;
+
+    /**
+     * after a failed de-queuing the next try is delayed by the first entry (values are seconds)
+     * The 2nd failed de-queue takes the seconds array-entry for delay, the 3rd takes the 3rd, etc...
+     */
+    private int[] retryIntervals;
+
+    /**
+     * EN-queuing speed can be throttled by delaying the "ok" response.
+     * This is a simple linear factor. E.g. when set to "0.3" this means that
+     * enqueuing is delayed for 0.3 seconds when queue is of length 1000 (0.6 seconds when length is 2000 etc...)
+     * "0" means: turn of this feature
+     */
+    private float enqueueDelayMillisPerSize = 0f;
+
+    /**
+     * When EN-queue slowdown is used ({@link #enqueueDelayMillisPerSize}) you can limit the maximum delay here.
+     * E.g. when set to "1000" you still have a maximum EN-queuing rate of "one per second" - even when the queue already is very large
+     *
+     * default "0" means: no limit
+     */
+    private int enqueueMaxDelayMillis = 0;
 
     public String getPattern() {
+        return pattern.pattern();
+    }
+
+    /**
+     * access the precompiled Pattern
+     * Explicit NOT a Getter (i.e. not named "get....") sp it's not JSON-serialized
+     *
+     * @return the compiled Pattern to quickly match (or not match) queue name
+     */
+    public Pattern compiledPattern() {
         return pattern;
     }
 
-    public List<Integer> getRetryIntervals() {
+    public int[] getRetryIntervals() {
         return retryIntervals;
     }
 
-    public static QueueConfigurationBuilder with() {
-        return new QueueConfigurationBuilder();
+    public float getEnqueueDelayMillisPerSize() {
+        return enqueueDelayMillisPerSize;
     }
-    
+
+    public int getEnqueueMaxDelayMillis() {
+        return enqueueMaxDelayMillis;
+    }
+
     public JsonObject asJsonObject() {
         return JsonObject.mapFrom(this);
     }
@@ -38,28 +68,35 @@ public class QueueConfiguration {
         return jsonObject.mapTo(QueueConfiguration.class);
     }
 
-    private QueueConfiguration(QueueConfigurationBuilder builder) {
-        this.pattern = builder.pattern;
-        this.retryIntervals = builder.retryIntervals;
+    public QueueConfiguration withPattern(String pattern) {
+        // this also checks for correct RegEx-Pattern
+        this.pattern = Pattern.compile(pattern);
+        return this;
     }
-    
-    public static class QueueConfigurationBuilder {
-        
-        String pattern;
-        List<Integer> retryIntervals;
-        
-        public QueueConfigurationBuilder pattern(String pattern) {
-            this.pattern = pattern;
-            return this;
+
+    public QueueConfiguration withRetryIntervals(int... retryIntervals) {
+        for (int i = 0; i < retryIntervals.length; i++) {
+            if (retryIntervals[i] < 1) {
+                throw new IllegalArgumentException("retryIntervals must all be >=1 (second) but is " + Arrays.toString(retryIntervals));
+            }
         }
-        
-        public QueueConfigurationBuilder retryIntervals(List<Integer> retryIntervals) {
-            this.retryIntervals = retryIntervals;
-            return this;
+        this.retryIntervals = retryIntervals;
+        return this;
+    }
+
+    public QueueConfiguration withEnqueueDelayMillisPerSize(float enqueueDelayMillisPerSize) {
+        if (enqueueDelayMillisPerSize <= 0f) {
+            throw new IllegalArgumentException("enqueueDelayMillisPerSize must be >0 but is " + enqueueDelayMillisPerSize);
         }
-        
-        public QueueConfiguration build() {
-            return new QueueConfiguration(this);
+        this.enqueueDelayMillisPerSize = enqueueDelayMillisPerSize;
+        return this;
+    }
+
+    public QueueConfiguration withEnqueueMaxDelayMillis(int enqueueMaxDelayMillis) {
+        if (enqueueMaxDelayMillis < 0) {
+            throw new IllegalArgumentException("enqueueMaxDelayMillis must be >=0 but is " + enqueueMaxDelayMillis);
         }
+        this.enqueueMaxDelayMillis = enqueueMaxDelayMillis;
+        return this;
     }
 }

--- a/src/main/java/org/swisspush/redisques/util/QueueConfiguration.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueConfiguration.java
@@ -20,14 +20,17 @@ public class QueueConfiguration {
 
     /**
      * EN-queuing speed can be throttled by delaying the "ok" response.
-     * This is a simple linear factor. E.g. when set to "0.3" this means that
-     * enqueuing is delayed for 0.3 seconds when queue is of length 1000 (0.6 seconds when length is 2000 etc...)
+     *
+     * This is a simple linear factor. E.g. when set to "300" this means that
+     * "success" enqueuing-reply is delayed for 300 ms (0.3 seconds= when queue is of
+     * length 1000 (0.6 seconds when length is 2000 etc...)
+     *
      * "0" means: turn of this feature
      */
-    private float enqueueDelayMillisPerSize = 0f;
+    private float enqueueDelayFactorMillis = 0f;
 
     /**
-     * When EN-queue slowdown is used ({@link #enqueueDelayMillisPerSize}) you can limit the maximum delay here.
+     * When EN-queue slowdown is used ({@link #enqueueDelayFactorMillis}) you can limit the maximum delay here.
      * E.g. when set to "1000" you still have a maximum EN-queuing rate of "one per second" - even when the queue already is very large
      *
      * default "0" means: no limit
@@ -52,8 +55,8 @@ public class QueueConfiguration {
         return retryIntervals;
     }
 
-    public float getEnqueueDelayMillisPerSize() {
-        return enqueueDelayMillisPerSize;
+    public float getEnqueueDelayFactorMillis() {
+        return enqueueDelayFactorMillis;
     }
 
     public int getEnqueueMaxDelayMillis() {
@@ -84,11 +87,11 @@ public class QueueConfiguration {
         return this;
     }
 
-    public QueueConfiguration withEnqueueDelayMillisPerSize(float enqueueDelayMillisPerSize) {
-        if (enqueueDelayMillisPerSize <= 0f) {
-            throw new IllegalArgumentException("enqueueDelayMillisPerSize must be >0 but is " + enqueueDelayMillisPerSize);
+    public QueueConfiguration withEnqueueDelayMillisPerSize(float enqueueDelayFactorMillis) {
+        if (enqueueDelayFactorMillis <= 0f) {
+            throw new IllegalArgumentException("enqueueDelayMillisPerSize must be >0 but is " + enqueueDelayFactorMillis);
         }
-        this.enqueueDelayMillisPerSize = enqueueDelayMillisPerSize;
+        this.enqueueDelayFactorMillis = enqueueDelayFactorMillis;
         return this;
     }
 

--- a/src/test/java/org/swisspush/redisques/RedisQuesTest.java
+++ b/src/test/java/org/swisspush/redisques/RedisQuesTest.java
@@ -40,10 +40,10 @@ public class RedisQuesTest extends AbstractTestCase {
                 .processorAddress(PROCESSOR_ADDRESS)
                 .redisEncoding("ISO-8859-1")
                 .refreshPeriod(2)
-                .queueConfigurations(Arrays.asList(QueueConfiguration.with()
-                        .pattern("queue.*")
-                        .retryIntervals(Arrays.asList(2, 7, 12, 17, 22, 27, 32, 37, 42, 47, 52))
-                        .build()))
+                .queueConfigurations(Arrays.asList(new QueueConfiguration()
+                        .withPattern("queue.*")
+                        .withRetryIntervals(2, 7, 12, 17, 22, 27, 32, 37, 42, 47, 52))
+                )
                 .build()
                 .asJsonObject();
 

--- a/src/test/java/org/swisspush/redisques/slowdown/EnqueueThrottleTest.java
+++ b/src/test/java/org/swisspush/redisques/slowdown/EnqueueThrottleTest.java
@@ -1,0 +1,110 @@
+package org.swisspush.redisques.slowdown;
+
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.swisspush.redisques.RedisQues;
+import org.swisspush.redisques.util.QueueConfiguration;
+import org.swisspush.redisques.util.RedisquesAPI;
+import org.swisspush.redisques.util.RedisquesConfiguration;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.swisspush.redisques.util.RedisquesAPI.*;
+
+@RunWith(VertxUnitRunner.class)
+public class EnqueueThrottleTest {
+
+    private static final String REDISQUES_ADDRESS = "EnqueueThrottleTest-RedisQues";
+    private static final String PROCESSOR_ADDRESS = "EnqueueThrottleTest-Processor";
+    private static final String QUEUE_NAME = "EnqueueThrottleTest-q1";
+
+    @ClassRule
+    public static RunTestOnContext RULE = new RunTestOnContext(new VertxOptions().setBlockedThreadCheckInterval(10_000));
+
+    @Before
+    public void deployRedisQuesAndRegisterProcessor(TestContext testContext) {
+        Async async = testContext.async();
+        Vertx vertx = RULE.vertx();
+
+        RedisquesConfiguration redisquesConfig = RedisquesConfiguration.with()
+                .address(REDISQUES_ADDRESS)
+                .processorAddress(PROCESSOR_ADDRESS)
+                .httpRequestHandlerEnabled(true)
+                .refreshPeriod(2)
+                .checkInterval(10)
+                .queueConfigurations(Arrays.asList(
+                  new QueueConfiguration().withPattern(QUEUE_NAME).withEnqueueDelayMillisPerSize(500).withEnqueueMaxDelayMillis(1700)
+                ))
+                .build();
+
+        vertx.eventBus().consumer(PROCESSOR_ADDRESS, this::processor);
+
+        vertx.deployVerticle(new RedisQues(), new DeploymentOptions().setConfig(redisquesConfig.asJsonObject()), done -> {
+            JsonObject delete = RedisquesAPI.buildDeleteAllQueueItemsOperation(QUEUE_NAME);
+            vertx.eventBus().send(REDISQUES_ADDRESS, delete, deleteDone -> {
+                async.complete();
+            });
+        });
+    }
+
+    private static boolean blockProcessor = true;
+    private static HashSet<String> queueMirror = new HashSet<>();
+
+    private void processor(Message<JsonObject> msg) {
+        String message = msg.body().getString("payload");
+        if (!blockProcessor) {
+            queueMirror.remove(message);
+        }
+        String replyStatus = blockProcessor ? ERROR : OK;
+        System.out.println("Processor received: " + message + " and will reply: " + replyStatus);
+        msg.reply(new JsonObject().put(STATUS, replyStatus));
+    }
+
+    @Test
+    public void testEnqueuThrottling(TestContext testContext) {
+        Async async = testContext.async();
+        sendAMessage(testContext);
+        Vertx vertx = RULE.vertx();
+        vertx.setPeriodic(100, id -> {
+            if (queueMirror.isEmpty()) {
+                System.out.println("All messages (as in our queueMirror) processed --> done");
+                async.complete();
+            }
+        });
+    }
+
+    private void sendAMessage(TestContext testContext) {
+        int num = queueMirror.size();
+        if (num == 6) { // the 5th and 6th message (Hallo-4 and Hallo-5) reach "enqueueMaxDelayMillis" - don't need more
+            System.out.println("All messages enqueued - will now allow Processor to conume successfully");
+            blockProcessor = false;
+            return;
+        }
+        String message = "Hallo-" + num;
+        queueMirror.add(message);
+        System.out.println("enqueue " + message);
+        JsonObject enque = RedisquesAPI.buildEnqueueOperation(QUEUE_NAME, message);
+        long t0 = System.nanoTime();
+        RULE.vertx().eventBus().send(REDISQUES_ADDRESS, enque, result -> {
+            long enqueuDurationMillis = (System.nanoTime() - t0) / 1_000_000;
+            long expectedDurationMillis = Math.min(num * 500, 1700); // see QueueConfiguration above
+            if (Math.abs(enqueuDurationMillis - expectedDurationMillis) > 100) {
+                testContext.fail("expected " + expectedDurationMillis + " but took " + enqueuDurationMillis);
+            }
+            System.out.println("enqueue " + message + " done after " + enqueuDurationMillis + " ms (expected " + expectedDurationMillis + " ms)");
+            sendAMessage(testContext);
+        });
+    }
+}

--- a/src/test/java/org/swisspush/redisques/util/RedisquesConfigurationTest.java
+++ b/src/test/java/org/swisspush/redisques/util/RedisquesConfigurationTest.java
@@ -56,10 +56,9 @@ public class RedisquesConfigurationTest {
                 .httpRequestHandlerPrefix("/queuing/test")
                 .httpRequestHandlerPort(7171)
                 .httpRequestHandlerUserHeader("x-custom-user-header")
-                .queueConfigurations(Arrays.asList(QueueConfiguration.with()
-                        .pattern("vehicle-.*")
-                        .retryIntervals(Arrays.asList(10, 20, 30, 60))
-                        .build()))
+                .queueConfigurations(Arrays.asList(
+                        new QueueConfiguration().withPattern("vehicle-.*").withRetryIntervals(10, 20, 30, 60)
+                ))
                 .build();
 
         // default values
@@ -85,7 +84,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(config.getQueueConfigurations().size(), 1);
         QueueConfiguration queueConfiguration = config.getQueueConfigurations().get(0);
         testContext.assertEquals(queueConfiguration.getPattern(), "vehicle-.*");
-        testContext.assertEquals(queueConfiguration.getRetryIntervals(), Arrays.asList(10, 20, 30, 60));
+        testContext.assertTrue(Arrays.equals(queueConfiguration.getRetryIntervals(), new int[]{10, 20, 30, 60}));
     }
 
     @Test
@@ -124,10 +123,9 @@ public class RedisquesConfigurationTest {
                 .processorDelayMax(50)
                 .httpRequestHandlerPort(7171)
                 .httpRequestHandlerUserHeader("x-custom-user-header")
-                .queueConfigurations(Arrays.asList(QueueConfiguration.with()
-                        .pattern("vehicle-.*")
-                        .retryIntervals(Arrays.asList(10, 20, 30, 60))
-                        .build()))
+                .queueConfigurations(Arrays.asList(
+                        new QueueConfiguration().withPattern("vehicle-.*").withRetryIntervals(10, 20, 30, 60)
+                ))
                 .build();
 
         JsonObject json = config.asJsonObject();
@@ -156,8 +154,8 @@ public class RedisquesConfigurationTest {
         List<JsonObject> queueConfigurationJsonObjects = queueConfigurationsJsonArray.getList();
         testContext.assertEquals(queueConfigurationJsonObjects.size(), 1);
         JsonObject queueConfigurationJsonObject = queueConfigurationJsonObjects.get(0);
-        testContext.assertEquals(queueConfigurationJsonObject.getString(QueueConfiguration.PROP_PATTERN), "vehicle-.*");
-        testContext.assertEquals(queueConfigurationJsonObject.getJsonArray(QueueConfiguration.PROP_RETRY_INTERVALS).getList(), Arrays.asList(10, 20, 30, 60));
+        testContext.assertEquals(queueConfigurationJsonObject.getString("pattern"), "vehicle-.*");
+        testContext.assertEquals(queueConfigurationJsonObject.getJsonArray("retryIntervals").getList(), Arrays.asList(10, 20, 30, 60));
     }
 
     @Test
@@ -202,10 +200,8 @@ public class RedisquesConfigurationTest {
         json.put(PROP_HTTP_REQUEST_HANDLER_PREFIX, "/queuing/test123");
         json.put(PROP_HTTP_REQUEST_HANDLER_PORT, 7171);
         json.put(PROP_HTTP_REQUEST_HANDLER_USER_HEADER, "x-custom-user-header");
-        json.put(PROP_QUEUE_CONFIGURATIONS, new JsonArray(Arrays.asList(QueueConfiguration.with()
-                .pattern("vehicle-.*")
-                .retryIntervals(Arrays.asList(10, 20, 30, 60))
-                .build().asJsonObject())));
+        json.put(PROP_QUEUE_CONFIGURATIONS, new JsonArray(Arrays.asList(new QueueConfiguration().withPattern("vehicle-.*").withRetryIntervals(10, 20, 30, 60)
+                .asJsonObject())));
 
         RedisquesConfiguration config = fromJsonObject(json);
         testContext.assertEquals(config.getAddress(), "new_address");
@@ -228,7 +224,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(config.getQueueConfigurations().size(), 1);
         QueueConfiguration queueConfiguration = config.getQueueConfigurations().get(0);
         testContext.assertEquals(queueConfiguration.getPattern(), "vehicle-.*");
-        testContext.assertEquals(queueConfiguration.getRetryIntervals(), Arrays.asList(10, 20, 30, 60));
+        testContext.assertTrue(Arrays.equals(queueConfiguration.getRetryIntervals(), new int[]{10, 20, 30, 60}));
     }
 
     @Test


### PR DESCRIPTION
Background: Redis-Memory is limited - therefore queue sizes are limited (queue length multiplied with average queue entry size).
So at some point, EN-queuing suddenly fails (presumed that DE-queuing is not possible for a while)

For stability reasons we now can slowly increase a backpressure towards EN-queuing process (http- or EventBus-Clients) by delaying a "success enqueue"-reply more and more. Presuming that the originating EN-queuing process also works sequentially (i.e. it only requests to enqueue a next message when the previous message is successfully enqueued) this simple mechano helps to secure 'our' Redis memory and give us more time (minutes or even hours) to react.

There are now two additonal config options 'per QueueName-pattern':
- enqueueDelayMillisPerSize
- enqueueMaxDelayMillis

Closes #70

Addtionally:
- simplified Config-Object (i.e.: remove the 'Builder'-pattern. Seems to be useless but enforces duplicate code)
- now using a pre-compiled RegEx-Pattern instead of using method String#matches (which requires to compile the RegEx over and over again)
- reduced string-concat operation within RedisQues when building Redis-Key-Prefixes over and over again
- harmonized naming: variable-name "queueName" is now used throughout RedisQues-class