### PR TITLE
Allow disable of queuename decoding

### DIFF
--- a/src/main/java/org/swisspush/redisques/util/RedisquesConfiguration.java
+++ b/src/main/java/org/swisspush/redisques/util/RedisquesConfiguration.java
@@ -32,6 +32,7 @@ public class RedisquesConfiguration {
     private Integer httpRequestHandlerPort;
     private String httpRequestHandlerUserHeader;
     private List<QueueConfiguration> queueConfigurations;
+    private boolean enableQueueNameDecoding;
 
     private static final int DEFAULT_CHECK_INTERVAL = 60; // 60s
     private static final long DEFAULT_PROCESSOR_DELAY_MAX = 0;
@@ -53,6 +54,7 @@ public class RedisquesConfiguration {
     public static final String PROP_HTTP_REQUEST_HANDLER_PORT = "httpRequestHandlerPort";
     public static final String PROP_HTTP_REQUEST_HANDLER_USER_HEADER = "httpRequestHandlerUserHeader";
     public static final String PROP_QUEUE_CONFIGURATIONS = "queueConfigurations";
+    public static final String PROP_ENABLE_QUEUE_NAME_DECODING = "enableQueueNameDecoding";
 
     /**
      * Constructor with default values. Use the {@link RedisquesConfigurationBuilder} class
@@ -66,7 +68,8 @@ public class RedisquesConfiguration {
                                   String redisHost, int redisPort, String redisAuth, String redisEncoding, int checkInterval,
                                   int processorTimeout, long processorDelayMax, boolean httpRequestHandlerEnabled,
                                   String httpRequestHandlerPrefix, Integer httpRequestHandlerPort,
-                                  String httpRequestHandlerUserHeader, List<QueueConfiguration> queueConfigurations) {
+                                  String httpRequestHandlerUserHeader, List<QueueConfiguration> queueConfigurations,
+                                  boolean enableQueueNameDecoding) {
         this.address = address;
         this.configurationUpdatedAddress = configurationUpdatedAddress;
         this.redisPrefix = redisPrefix;
@@ -100,6 +103,7 @@ public class RedisquesConfiguration {
         this.httpRequestHandlerPort = httpRequestHandlerPort;
         this.httpRequestHandlerUserHeader = httpRequestHandlerUserHeader;
         this.queueConfigurations = queueConfigurations;
+        this.enableQueueNameDecoding = enableQueueNameDecoding;
     }
 
     public static RedisquesConfigurationBuilder with(){
@@ -110,7 +114,7 @@ public class RedisquesConfiguration {
         this(builder.address, builder.configurationUpdatedAddress, builder.redisPrefix, builder.processorAddress, builder.refreshPeriod,
                 builder.redisHost, builder.redisPort, builder.redisAuth, builder.redisEncoding, builder.checkInterval,
                 builder.processorTimeout, builder.processorDelayMax, builder.httpRequestHandlerEnabled, builder.httpRequestHandlerPrefix,
-                builder.httpRequestHandlerPort, builder.httpRequestHandlerUserHeader, builder.queueConfigurations);
+                builder.httpRequestHandlerPort, builder.httpRequestHandlerUserHeader, builder.queueConfigurations, builder.enableQueueNameDecoding);
     }
 
     public JsonObject asJsonObject(){
@@ -132,6 +136,7 @@ public class RedisquesConfiguration {
         obj.put(PROP_HTTP_REQUEST_HANDLER_PORT, getHttpRequestHandlerPort());
         obj.put(PROP_HTTP_REQUEST_HANDLER_USER_HEADER, getHttpRequestHandlerUserHeader());
         obj.put(PROP_QUEUE_CONFIGURATIONS, new JsonArray(getQueueConfigurations().stream().map(QueueConfiguration::asJsonObject).collect(Collectors.toList())));
+        obj.put(PROP_ENABLE_QUEUE_NAME_DECODING, getEnableQueueNameDecoding());
             
         return obj;
     }
@@ -192,6 +197,9 @@ public class RedisquesConfiguration {
                     .map(jsonObject -> QueueConfiguration.fromJsonObject((JsonObject)jsonObject))
                     .collect(Collectors.toList()));
         }
+        if(json.containsKey(PROP_ENABLE_QUEUE_NAME_DECODING)) {
+            builder.enableQueueNameDecoding(json.getBoolean(PROP_ENABLE_QUEUE_NAME_DECODING));
+        }
         return builder.build();
     }
 
@@ -236,6 +244,10 @@ public class RedisquesConfiguration {
     public String getHttpRequestHandlerUserHeader() { return httpRequestHandlerUserHeader; }
     
     public List<QueueConfiguration> getQueueConfigurations() { return queueConfigurations; }
+
+    public boolean getEnableQueueNameDecoding() {
+        return enableQueueNameDecoding;
+    }
 
     /**
      * Gets the value for the vertx periodic timer.
@@ -284,6 +296,7 @@ public class RedisquesConfiguration {
         private Integer httpRequestHandlerPort;
         private String httpRequestHandlerUserHeader;
         private List<QueueConfiguration> queueConfigurations;
+        private boolean enableQueueNameDecoding;
 
         public RedisquesConfigurationBuilder(){
             this.address = "redisques";
@@ -302,6 +315,7 @@ public class RedisquesConfiguration {
             this.httpRequestHandlerPort = 7070;
             this.httpRequestHandlerUserHeader = "x-rp-usr";
             this.queueConfigurations = new LinkedList<>();
+            this.enableQueueNameDecoding = true;
         }
 
         public RedisquesConfigurationBuilder address(String address){
@@ -386,6 +400,11 @@ public class RedisquesConfiguration {
 
         public RedisquesConfigurationBuilder queueConfigurations(List<QueueConfiguration> queueConfigurations){
             this.queueConfigurations = queueConfigurations;
+            return this;
+        }
+
+        public RedisquesConfigurationBuilder enableQueueNameDecoding(boolean enableQueueNameDecoding) {
+            this.enableQueueNameDecoding = enableQueueNameDecoding;
             return this;
         }
 

--- a/src/test/java/org/swisspush/redisques/handler/DisableQueueNameEncodingTest.java
+++ b/src/test/java/org/swisspush/redisques/handler/DisableQueueNameEncodingTest.java
@@ -1,0 +1,112 @@
+package org.swisspush.redisques.handler;
+
+import io.restassured.RestAssured;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.Timeout;
+import org.hamcrest.Matchers;
+import org.junit.*;
+import org.swisspush.redisques.AbstractTestCase;
+import org.swisspush.redisques.RedisQues;
+import org.swisspush.redisques.util.RedisquesConfiguration;
+import redis.clients.jedis.Jedis;
+
+import static io.restassured.RestAssured.when;
+import static org.swisspush.redisques.util.RedisquesAPI.buildEnqueueOperation;
+
+/**
+ * Very similar to {@link RedisquesHttpRequestHandlerTest}, but explicitly disable the queue name decoding.
+ */
+public class DisableQueueNameEncodingTest extends AbstractTestCase {
+    private Vertx testVertx;
+
+    @Rule
+    public Timeout rule = Timeout.seconds(5);
+
+    private static boolean urlEncodingEnabled;
+
+    @BeforeClass
+    public static void beforeClass() {
+        RestAssured.baseURI = "http://127.0.0.1/";
+        RestAssured.port = 7070;
+        // cache previous value
+        urlEncodingEnabled = RestAssured.urlEncodingEnabled;
+        RestAssured.urlEncodingEnabled = false;
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        // restore previous value
+        RestAssured.urlEncodingEnabled = urlEncodingEnabled;
+    }
+
+    @Before
+    public void deployRedisques(TestContext context) {
+        Async async = context.async();
+        testVertx = Vertx.vertx();
+
+        JsonObject config = RedisquesConfiguration.with()
+            .address(getRedisquesAddress())
+            .processorAddress("processor-address")
+            .redisEncoding("ISO-8859-1")
+            .refreshPeriod(2)
+            .httpRequestHandlerEnabled(true)
+            .httpRequestHandlerPort(7070)
+            .enableQueueNameDecoding(false)
+            .build()
+            .asJsonObject();
+
+        RedisQues redisQues = new RedisQues();
+
+        testVertx.deployVerticle(redisQues, new DeploymentOptions().setConfig(config), context.asyncAssertSuccess(event -> {
+            deploymentId = event;
+            log.info("vert.x Deploy - " + redisQues.getClass().getSimpleName() + " was successful.");
+            jedis = new Jedis("localhost", 6379, 5000);
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                //do nothing
+            }
+            async.complete();
+        }));
+        async.awaitSuccess();
+    }
+
+    @After
+    public void tearDown(TestContext context) {
+        testVertx.undeploy(deploymentId, context.asyncAssertSuccess(Void -> {
+            testVertx.close(context.asyncAssertSuccess());
+            context.async().complete();
+        }));
+    }
+
+    protected void eventBusSend(JsonObject operation, Handler<AsyncResult<Message<JsonObject>>> handler) {
+        testVertx.eventBus().send(getRedisquesAddress(), operation, handler);
+    }
+
+    @Test
+    public void disableEncodingQueueNameTest(TestContext context) {
+        Async async = context.async();
+        flushAll();
+        eventBusSend(buildEnqueueOperation("queue+with_plus+signs", "helloEnqueue"), message -> {
+            eventBusSend(buildEnqueueOperation("queue+with_plus+signs", "helloEnqueue2"), message2 -> {
+                when().get("/queuing/queues/queue+with_plus+signs")
+                    .then().assertThat()
+                    .statusCode(200)
+                    // has a potential to be very shaky, i.e. if the json response contains spaces
+                    // we can't use `.body("queue+with_plus+signs", hasItems("helloEnqueue", "helloEnqueue2"))`,
+                    // because restassured is interpreting the plus sign (+) in some way
+                    .body(Matchers.equalTo("{\"queue+with_plus+signs\":[\"helloEnqueue\",\"helloEnqueue2\"]}"))
+                ;
+                async.complete();
+            });
+        });
+        async.awaitSuccess();
+    }
+}


### PR DESCRIPTION
An earlier change introduced a bug when queue names contained plus signs, when decoding, these would be converted to spaces.

This doesn't directly address this bug, but instead it allows the disabling of the decoding mechanism.