### PR TITLE
#84 - SDCISA-3814 Provide efficient statistics API for Queue monitoring

### DIFF
--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -1418,7 +1418,7 @@ public class RedisQues extends AbstractVerticle {
      * given filter pattern.
      */
     private void getQueuesStatistics(Message<JsonObject> event,
-        Result<Optional<Pattern>, String> filterPattern) {
+            Result<Optional<Pattern>, String> filterPattern) {
         if (filterPattern.isErr()) {
             event.reply(createErrorReply().put(ERROR_TYPE, BAD_INPUT)
                 .put(MESSAGE, filterPattern.getErr()));

--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -1,24 +1,6 @@
 package org.swisspush.redisques;
 
-import static org.swisspush.redisques.util.RedisquesAPI.BAD_INPUT;
-import static org.swisspush.redisques.util.RedisquesAPI.BUFFER;
-import static org.swisspush.redisques.util.RedisquesAPI.ERROR;
-import static org.swisspush.redisques.util.RedisquesAPI.ERROR_TYPE;
-import static org.swisspush.redisques.util.RedisquesAPI.INDEX;
-import static org.swisspush.redisques.util.RedisquesAPI.LIMIT;
-import static org.swisspush.redisques.util.RedisquesAPI.LOCKS;
-import static org.swisspush.redisques.util.RedisquesAPI.MESSAGE;
-import static org.swisspush.redisques.util.RedisquesAPI.OK;
-import static org.swisspush.redisques.util.RedisquesAPI.OPERATION;
-import static org.swisspush.redisques.util.RedisquesAPI.PAYLOAD;
-import static org.swisspush.redisques.util.RedisquesAPI.PROCESSOR_DELAY_MAX;
-import static org.swisspush.redisques.util.RedisquesAPI.QUEUENAME;
-import static org.swisspush.redisques.util.RedisquesAPI.QUEUES;
-import static org.swisspush.redisques.util.RedisquesAPI.QueueOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.REQUESTED_BY;
-import static org.swisspush.redisques.util.RedisquesAPI.STATUS;
-import static org.swisspush.redisques.util.RedisquesAPI.UNLOCK;
-import static org.swisspush.redisques.util.RedisquesAPI.VALUE;
+import static org.swisspush.redisques.util.RedisquesAPI.*;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.AsyncResult;

--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -1,6 +1,24 @@
 package org.swisspush.redisques;
 
-import static org.swisspush.redisques.util.RedisquesAPI.*;
+import static org.swisspush.redisques.util.RedisquesAPI.BAD_INPUT;
+import static org.swisspush.redisques.util.RedisquesAPI.BUFFER;
+import static org.swisspush.redisques.util.RedisquesAPI.ERROR;
+import static org.swisspush.redisques.util.RedisquesAPI.ERROR_TYPE;
+import static org.swisspush.redisques.util.RedisquesAPI.INDEX;
+import static org.swisspush.redisques.util.RedisquesAPI.LIMIT;
+import static org.swisspush.redisques.util.RedisquesAPI.LOCKS;
+import static org.swisspush.redisques.util.RedisquesAPI.MESSAGE;
+import static org.swisspush.redisques.util.RedisquesAPI.OK;
+import static org.swisspush.redisques.util.RedisquesAPI.OPERATION;
+import static org.swisspush.redisques.util.RedisquesAPI.PAYLOAD;
+import static org.swisspush.redisques.util.RedisquesAPI.PROCESSOR_DELAY_MAX;
+import static org.swisspush.redisques.util.RedisquesAPI.QUEUENAME;
+import static org.swisspush.redisques.util.RedisquesAPI.QUEUES;
+import static org.swisspush.redisques.util.RedisquesAPI.QueueOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.REQUESTED_BY;
+import static org.swisspush.redisques.util.RedisquesAPI.STATUS;
+import static org.swisspush.redisques.util.RedisquesAPI.UNLOCK;
+import static org.swisspush.redisques.util.RedisquesAPI.VALUE;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.AsyncResult;
@@ -168,8 +186,7 @@ public class RedisQues extends AbstractVerticle {
         }
         if (log.isDebugEnabled()) {
             log.debug(
-                "RedisQues Got registration request for queue " + queueName + " from consumer: "
-                    + uid);
+                "RedisQues Got registration request for queue {} from consumer: {}", queueName, uid);
         }
         // Try to register for this queue
         redisSetWithOptions(consumersPrefix + queueName, uid, true, consumerLockTime, event -> {
@@ -1376,14 +1393,14 @@ public class RedisQues extends AbstractVerticle {
     /**
      * Retrieve the size of the queues matching the given filter pattern
      */
-    private void getQueuesItemsCount(Message<JsonObject> event,
-        Result<Optional<Pattern>, String> filterPatternResult) {
+    private void getQueuesItemsCount(Message<JsonObject> event, Result<Optional<Pattern>, String> filterPatternResult) {
         if (filterPatternResult.isErr()) {
             event.reply(createErrorReply().put(ERROR_TYPE, BAD_INPUT)
                 .put(MESSAGE, filterPatternResult.getErr()));
         } else {
             redisAPI.zrangebyscore(List.of(queuesKey, String.valueOf(getMaxAgeTimestamp()), "+inf"),
-                new GetQueuesItemsCountHandler(event, filterPatternResult.getOk(),luaScriptManager, queuesPrefix));
+                new GetQueuesItemsCountHandler(event, filterPatternResult.getOk(), luaScriptManager,
+                    queuesPrefix));
         }
     }
 

--- a/src/main/java/org/swisspush/redisques/handler/GetAllLocksHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetAllLocksHandler.java
@@ -8,10 +8,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.redis.client.Response;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
-import org.swisspush.redisques.util.QueueHandlerUtil;
 
 import static org.swisspush.redisques.util.RedisquesAPI.*;
 

--- a/src/main/java/org/swisspush/redisques/handler/GetAllLocksHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetAllLocksHandler.java
@@ -6,8 +6,10 @@ import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import org.swisspush.redisques.util.QueueHandlerUtil;
 
 import static org.swisspush.redisques.util.RedisquesAPI.*;
 
@@ -30,20 +32,8 @@ public class GetAllLocksHandler implements Handler<AsyncResult<JsonArray>> {
     public void handle(AsyncResult<JsonArray> reply) {
         if (reply.succeeded() && reply.result() != null) {
             JsonObject result = new JsonObject();
-            JsonArray locks = reply.result();
-            if(filterPattern.isPresent()){
-                Pattern pattern = filterPattern.get();
-                JsonArray filteredLocks = new JsonArray();
-                for (int i = 0; i < locks.size(); i++) {
-                    String lock = locks.getString(i);
-                    if(pattern.matcher(lock).find()){
-                        filteredLocks.add(lock);
-                    }
-                }
-                result.put("locks", filteredLocks);
-            } else {
-                result.put("locks", locks);
-            }
+            List<String> filteredLocks = QueueHandlerUtil.filterQueues(reply.result(), filterPattern);
+            result.put(LOCKS, filteredLocks);
             event.reply(new JsonObject().put(STATUS, OK).put(VALUE, result));
         } else {
             event.reply(new JsonObject().put(STATUS, ERROR));

--- a/src/main/java/org/swisspush/redisques/handler/GetQueuesHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueuesHandler.java
@@ -9,11 +9,8 @@ import io.vertx.redis.client.Response;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
-import org.swisspush.redisques.util.QueueHandlerUtil;
-import org.swisspush.redisques.util.RedisquesAPI;
 
 import static org.swisspush.redisques.util.RedisquesAPI.*;
 
@@ -48,13 +45,13 @@ public class GetQueuesHandler implements Handler<AsyncResult<Response>> {
                         filteredQueues.add(queue);
                     }
                 }
-                jsonRes.put(QUEUES_ARR, filteredQueues);
+                jsonRes.put(QUEUES, filteredQueues);
             } else {
                 List<String> arrayQueues = new ArrayList<>();
                 for (Response response : queues) {
                     arrayQueues.add(response.toString());
                 }
-                jsonRes.put(QUEUES_ARR, arrayQueues);
+                jsonRes.put(QUEUES, arrayQueues);
             }
             if(countOnly){
                 event.reply(new JsonObject().put(STATUS, OK).put(VALUE, jsonRes.getJsonArray(QUEUES).size()));

--- a/src/main/java/org/swisspush/redisques/handler/GetQueuesHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueuesHandler.java
@@ -15,8 +15,6 @@ import java.util.regex.Pattern;
 import static org.swisspush.redisques.util.RedisquesAPI.*;
 
 /**
- * Class GetQueuesHandler.
- *
  * @author https://github.com/mcweba [Marc-Andre Weber]
  */
 public class GetQueuesHandler implements Handler<AsyncResult<Response>> {

--- a/src/main/java/org/swisspush/redisques/handler/GetQueuesHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueuesHandler.java
@@ -6,13 +6,16 @@ import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import org.swisspush.redisques.util.QueueHandlerUtil;
+import org.swisspush.redisques.util.RedisquesAPI;
 
 import static org.swisspush.redisques.util.RedisquesAPI.*;
 
 /**
- * Class GetQueuesCountHandler.
+ * Class GetQueuesHandler.
  *
  * @author https://github.com/mcweba [Marc-Andre Weber]
  */
@@ -21,8 +24,6 @@ public class GetQueuesHandler implements Handler<AsyncResult<JsonArray>> {
     private Message<JsonObject> event;
     private Optional<Pattern> filterPattern;
     private boolean countOnly;
-
-    private static final String QUEUES_ARR = "queues";
 
     public GetQueuesHandler(Message<JsonObject> event, Optional<Pattern> filterPattern, boolean countOnly) {
         this.event = event;
@@ -34,26 +35,13 @@ public class GetQueuesHandler implements Handler<AsyncResult<JsonArray>> {
     public void handle(AsyncResult<JsonArray> reply) {
         if(reply.succeeded()){
             JsonObject result = new JsonObject();
-            JsonArray queues = reply.result();
-            if(filterPattern.isPresent()){
-                Pattern pattern = filterPattern.get();
-                JsonArray filteredQueues = new JsonArray();
-                for (int i = 0; i < queues.size(); i++) {
-                    String queue = queues.getString(i);
-                    if(pattern.matcher(queue).find()){
-                        filteredQueues.add(queue);
-                    }
-                }
-                result.put(QUEUES_ARR, filteredQueues);
-            } else {
-                result.put(QUEUES_ARR, queues);
-            }
+            List<String> queues = QueueHandlerUtil.filterQueues(reply.result(), filterPattern);
+            result.put(QUEUES, queues);
             if(countOnly){
-                event.reply(new JsonObject().put(STATUS, OK).put(VALUE, result.getJsonArray(QUEUES_ARR).size()));
+                event.reply(new JsonObject().put(STATUS, OK).put(VALUE, result.getJsonArray(QUEUES).size()));
             } else {
                 event.reply(new JsonObject().put(STATUS, OK).put(VALUE, result));
             }
-
         } else {
             event.reply(new JsonObject().put(STATUS, ERROR));
         }

--- a/src/main/java/org/swisspush/redisques/handler/GetQueuesItemsCountHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueuesItemsCountHandler.java
@@ -1,0 +1,81 @@
+package org.swisspush.redisques.handler;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.swisspush.redisques.lua.LuaScriptManager;
+import org.swisspush.redisques.util.HttpServerRequestUtil;
+import org.swisspush.redisques.util.QueueHandlerUtil;
+import org.swisspush.redisques.util.RedisquesAPI;
+
+import static org.swisspush.redisques.util.RedisquesAPI.*;
+
+/**
+ * Class GetQueueItemsCountHandler.
+ *
+ * @author https://github.com/mcweba [Marc-Andre Weber]
+ */
+public class GetQueuesItemsCountHandler implements Handler<AsyncResult<JsonArray>> {
+
+    private final Logger log = LoggerFactory.getLogger(GetQueuesItemsCountHandler.class);
+
+    private final Message<JsonObject> event;
+    private final Optional<Pattern> filterPattern;
+    private final LuaScriptManager luaScriptManager;
+    private final String queuesPrefix;
+
+    public GetQueuesItemsCountHandler(Message<JsonObject> event, Optional<Pattern> filterPattern, LuaScriptManager luaScriptManager, String queuesPrefix) {
+        this.event = event;
+        this.filterPattern = filterPattern;
+        this.luaScriptManager = luaScriptManager;
+        this.queuesPrefix = queuesPrefix;
+    }
+
+    @Override
+    public void handle(AsyncResult<JsonArray> handleQueues) {
+        if(handleQueues.succeeded()){
+            List<String> queues = QueueHandlerUtil.filterQueues(handleQueues.result(), filterPattern);
+            if (queues==null || queues.isEmpty()) {
+                log.debug("Queue count evaluation with empty queues");
+                event.reply(new JsonObject().put(STATUS, OK).put(QUEUES, new JsonArray()));
+                return;
+            }
+            List<String> keys = new ArrayList<>();
+            for (String queue : queues) {
+                keys.add(queuesPrefix + queue);
+            }
+            luaScriptManager.handleMultiListLength(keys, multiListLength -> {
+                if (multiListLength==null) {
+                    log.error("Unexepected queue MultiListLength result null");
+                    event.reply(new JsonObject().put(STATUS, ERROR));
+                    return;
+                }
+                if (multiListLength.size()!=queues.size()) {
+                    log.error("Unexpected queue MultiListLength result with unequal size {} : {}", queues.size(), multiListLength.size());
+                    event.reply(new JsonObject().put(STATUS, ERROR));
+                    return;
+                }
+                JsonArray result = new JsonArray();
+                for (int i = 0; i < queues.size(); i++) {
+                    String queueName = queues.get(i);
+                    result.add(new JsonObject()
+                        .put("name", queueName)
+                        .put("size", multiListLength.get(i)));
+                }
+                event.reply(new JsonObject().put(RedisquesAPI.STATUS, RedisquesAPI.OK)
+                    .put(QUEUES, result));
+            });
+        } else {
+            event.reply(new JsonObject().put(STATUS, ERROR));
+        }
+    }
+
+}

--- a/src/main/java/org/swisspush/redisques/handler/GetQueuesItemsCountHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueuesItemsCountHandler.java
@@ -32,7 +32,10 @@ public class GetQueuesItemsCountHandler implements Handler<AsyncResult<Response>
     private final LuaScriptManager luaScriptManager;
     private final String queuesPrefix;
 
-    public GetQueuesItemsCountHandler(Message<JsonObject> event, Optional<Pattern> filterPattern, LuaScriptManager luaScriptManager, String queuesPrefix) {
+    public GetQueuesItemsCountHandler(Message<JsonObject> event,
+        Optional<Pattern> filterPattern,
+        LuaScriptManager luaScriptManager,
+        String queuesPrefix) {
         this.event = event;
         this.filterPattern = filterPattern;
         this.luaScriptManager = luaScriptManager;
@@ -42,7 +45,8 @@ public class GetQueuesItemsCountHandler implements Handler<AsyncResult<Response>
     @Override
     public void handle(AsyncResult<Response> handleQueues) {
         if(handleQueues.succeeded()){
-            List<String> queues = QueueHandlerUtil.filterQueues(handleQueues.result(), filterPattern);
+            List<String> queues = QueueHandlerUtil.filterQueues(handleQueues.result(),
+                filterPattern);
             if (queues==null || queues.isEmpty()) {
                 log.debug("Queue count evaluation with empty queues");
                 event.reply(new JsonObject().put(STATUS, OK).put(QUEUES, new JsonArray()));
@@ -59,7 +63,8 @@ public class GetQueuesItemsCountHandler implements Handler<AsyncResult<Response>
                     return;
                 }
                 if (multiListLength.size()!=queues.size()) {
-                    log.error("Unexpected queue MultiListLength result with unequal size {} : {}", queues.size(), multiListLength.size());
+                    log.error("Unexpected queue MultiListLength result with unequal size {} : {}",
+                        queues.size(), multiListLength.size());
                     event.reply(new JsonObject().put(STATUS, ERROR));
                     return;
                 }

--- a/src/main/java/org/swisspush/redisques/handler/GetQueuesItemsCountHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueuesItemsCountHandler.java
@@ -67,8 +67,8 @@ public class GetQueuesItemsCountHandler implements Handler<AsyncResult<Response>
                 for (int i = 0; i < queues.size(); i++) {
                     String queueName = queues.get(i);
                     result.add(new JsonObject()
-                        .put("name", queueName)
-                        .put("size", multiListLength.get(i)));
+                        .put(MONITOR_QUEUE_NAME, queueName)
+                        .put(MONITOR_QUEUE_SIZE, multiListLength.get(i)));
                 }
                 event.reply(new JsonObject().put(RedisquesAPI.STATUS, RedisquesAPI.OK)
                     .put(QUEUES, result));

--- a/src/main/java/org/swisspush/redisques/handler/GetQueuesItemsCountHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueuesItemsCountHandler.java
@@ -7,12 +7,12 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import io.vertx.redis.client.Response;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import org.swisspush.redisques.lua.LuaScriptManager;
-import org.swisspush.redisques.util.HttpServerRequestUtil;
 import org.swisspush.redisques.util.QueueHandlerUtil;
 import org.swisspush.redisques.util.RedisquesAPI;
 
@@ -23,7 +23,7 @@ import static org.swisspush.redisques.util.RedisquesAPI.*;
  *
  * @author https://github.com/mcweba [Marc-Andre Weber]
  */
-public class GetQueuesItemsCountHandler implements Handler<AsyncResult<JsonArray>> {
+public class GetQueuesItemsCountHandler implements Handler<AsyncResult<Response>> {
 
     private final Logger log = LoggerFactory.getLogger(GetQueuesItemsCountHandler.class);
 
@@ -40,7 +40,7 @@ public class GetQueuesItemsCountHandler implements Handler<AsyncResult<JsonArray
     }
 
     @Override
-    public void handle(AsyncResult<JsonArray> handleQueues) {
+    public void handle(AsyncResult<Response> handleQueues) {
         if(handleQueues.succeeded()){
             List<String> queues = QueueHandlerUtil.filterQueues(handleQueues.result(), filterPattern);
             if (queues==null || queues.isEmpty()) {

--- a/src/main/java/org/swisspush/redisques/handler/GetQueuesStatisticsHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueuesStatisticsHandler.java
@@ -8,6 +8,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.redis.client.Response;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -20,7 +21,7 @@ import org.swisspush.redisques.util.QueueStatisticsCollector;
  * Retrieves in it's AsyncResult handler for all given queue names the queue statistics information
  * and returns the same in the event completion.
  */
-public class GetQueuesStatisticsHandler implements Handler<AsyncResult<JsonArray>> {
+public class GetQueuesStatisticsHandler implements Handler<AsyncResult<Response>> {
 
     private final Message<JsonObject> event;
     private final Optional<Pattern> filterPattern;
@@ -34,7 +35,7 @@ public class GetQueuesStatisticsHandler implements Handler<AsyncResult<JsonArray
     }
 
     @Override
-    public void handle(AsyncResult<JsonArray> handleQueues) {
+    public void handle(AsyncResult<Response> handleQueues) {
         if (handleQueues.succeeded()) {
             List<String> queues = QueueHandlerUtil
                 .filterQueues(handleQueues.result(), filterPattern);

--- a/src/main/java/org/swisspush/redisques/handler/GetQueuesStatisticsHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueuesStatisticsHandler.java
@@ -6,7 +6,6 @@ import static org.swisspush.redisques.util.RedisquesAPI.STATUS;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.eventbus.Message;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.redis.client.Response;
 import java.util.List;
@@ -27,7 +26,8 @@ public class GetQueuesStatisticsHandler implements Handler<AsyncResult<Response>
     private final Optional<Pattern> filterPattern;
     private final QueueStatisticsCollector queueStatisticsCollector;
 
-    public GetQueuesStatisticsHandler(Message<JsonObject> event, Optional<Pattern> filterPattern,
+    public GetQueuesStatisticsHandler(Message<JsonObject> event,
+        Optional<Pattern> filterPattern,
         QueueStatisticsCollector queueStatisticsCollector) {
         this.event = event;
         this.filterPattern = filterPattern;

--- a/src/main/java/org/swisspush/redisques/handler/GetQueuesStatisticsHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueuesStatisticsHandler.java
@@ -15,8 +15,6 @@ import org.swisspush.redisques.util.QueueHandlerUtil;
 import org.swisspush.redisques.util.QueueStatisticsCollector;
 
 /**
- * Class GetQueuesStatisticsHandler
- * <p>
  * Retrieves in it's AsyncResult handler for all given queue names the queue statistics information
  * and returns the same in the event completion.
  */

--- a/src/main/java/org/swisspush/redisques/handler/GetQueuesStatisticsHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueuesStatisticsHandler.java
@@ -1,0 +1,46 @@
+package org.swisspush.redisques.handler;
+
+import static org.swisspush.redisques.util.RedisquesAPI.ERROR;
+import static org.swisspush.redisques.util.RedisquesAPI.STATUS;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.swisspush.redisques.util.QueueHandlerUtil;
+import org.swisspush.redisques.util.QueueStatisticsCollector;
+
+/**
+ * Class GetQueuesStatisticsHandler
+ * <p>
+ * Retrieves in it's AsyncResult handler for all given queue names the queue statistics information
+ * and returns the same in the event completion.
+ */
+public class GetQueuesStatisticsHandler implements Handler<AsyncResult<JsonArray>> {
+
+    private final Message<JsonObject> event;
+    private final Optional<Pattern> filterPattern;
+    private final QueueStatisticsCollector queueStatisticsCollector;
+
+    public GetQueuesStatisticsHandler(Message<JsonObject> event, Optional<Pattern> filterPattern,
+        QueueStatisticsCollector queueStatisticsCollector) {
+        this.event = event;
+        this.filterPattern = filterPattern;
+        this.queueStatisticsCollector = queueStatisticsCollector;
+    }
+
+    @Override
+    public void handle(AsyncResult<JsonArray> handleQueues) {
+        if (handleQueues.succeeded()) {
+            List<String> queues = QueueHandlerUtil
+                .filterQueues(handleQueues.result(), filterPattern);
+            queueStatisticsCollector.getQueueStatistics(event, queues);
+        } else {
+            event.reply(new JsonObject().put(STATUS, ERROR));
+        }
+    }
+}

--- a/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
@@ -4,41 +4,7 @@ import static org.swisspush.redisques.util.HttpServerRequestUtil.decode;
 import static org.swisspush.redisques.util.HttpServerRequestUtil.encodePayload;
 import static org.swisspush.redisques.util.HttpServerRequestUtil.evaluateUrlParameterToBeEmptyOrTrue;
 import static org.swisspush.redisques.util.HttpServerRequestUtil.extractNonEmptyJsonArrayFromBody;
-import static org.swisspush.redisques.util.RedisquesAPI.BAD_INPUT;
-import static org.swisspush.redisques.util.RedisquesAPI.ERROR_TYPE;
-import static org.swisspush.redisques.util.RedisquesAPI.FILTER;
-import static org.swisspush.redisques.util.RedisquesAPI.LIMIT;
-import static org.swisspush.redisques.util.RedisquesAPI.LOCKS;
-import static org.swisspush.redisques.util.RedisquesAPI.MESSAGE;
-import static org.swisspush.redisques.util.RedisquesAPI.NO_SUCH_LOCK;
-import static org.swisspush.redisques.util.RedisquesAPI.OK;
-import static org.swisspush.redisques.util.RedisquesAPI.QUEUES;
-import static org.swisspush.redisques.util.RedisquesAPI.STATUS;
-import static org.swisspush.redisques.util.RedisquesAPI.VALUE;
-import static org.swisspush.redisques.util.RedisquesAPI.COUNT;
-import static org.swisspush.redisques.util.RedisquesAPI.buildAddQueueItemOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildBulkDeleteLocksOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildBulkDeleteQueuesOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildBulkPutLocksOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildDeleteAllLocksOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildDeleteAllQueueItemsOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildDeleteLockOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildDeleteQueueItemOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildEnqueueOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildGetAllLocksOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildGetConfigurationOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildGetLockOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueueItemOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueueItemsCountOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueueItemsOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueuesItemsCountOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueuesCountOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueuesOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueuesStatisticsOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildLockedEnqueueOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildPutLockOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildReplaceQueueItemOperation;
-import static org.swisspush.redisques.util.RedisquesAPI.buildSetConfigurationOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.*;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -834,14 +800,14 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
     }
 
     private List<JsonObject> sortJsonQueueArrayBySize(List<JsonObject> queueList) {
-        queueList.sort((left, right) -> right.getLong("size").compareTo(left.getLong("size")));
+        queueList.sort((left, right) -> right.getLong(MONITOR_QUEUE_SIZE).compareTo(left.getLong(MONITOR_QUEUE_SIZE)));
         return queueList;
     }
 
     private List<JsonObject> filterJsonQueueArrayNotEmpty(List<JsonObject> queueList) {
         return queueList.stream()
             .filter(
-                queue -> queue.getLong("size") > 0)
+                queue -> queue.getLong(MONITOR_QUEUE_SIZE) > 0)
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
@@ -141,7 +141,7 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
         /*
          * Get statistic information
          */
-        router.get(prefix + "/statistics/").handler(this::getQueuesStatistics);
+        router.get(prefix + "/statistics").handler(this::getQueuesStatistics);
 
         /*
          * Enqueue or LockedEnqueue

--- a/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
@@ -1,5 +1,45 @@
 package org.swisspush.redisques.handler;
 
+import static org.swisspush.redisques.util.HttpServerRequestUtil.decode;
+import static org.swisspush.redisques.util.HttpServerRequestUtil.encodePayload;
+import static org.swisspush.redisques.util.HttpServerRequestUtil.evaluateUrlParameterToBeEmptyOrTrue;
+import static org.swisspush.redisques.util.HttpServerRequestUtil.extractNonEmptyJsonArrayFromBody;
+import static org.swisspush.redisques.util.RedisquesAPI.BAD_INPUT;
+import static org.swisspush.redisques.util.RedisquesAPI.ERROR_TYPE;
+import static org.swisspush.redisques.util.RedisquesAPI.FILTER;
+import static org.swisspush.redisques.util.RedisquesAPI.LIMIT;
+import static org.swisspush.redisques.util.RedisquesAPI.LOCKS;
+import static org.swisspush.redisques.util.RedisquesAPI.MESSAGE;
+import static org.swisspush.redisques.util.RedisquesAPI.NO_SUCH_LOCK;
+import static org.swisspush.redisques.util.RedisquesAPI.OK;
+import static org.swisspush.redisques.util.RedisquesAPI.QUEUES;
+import static org.swisspush.redisques.util.RedisquesAPI.STATUS;
+import static org.swisspush.redisques.util.RedisquesAPI.VALUE;
+import static org.swisspush.redisques.util.RedisquesAPI.COUNT;
+import static org.swisspush.redisques.util.RedisquesAPI.buildAddQueueItemOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildBulkDeleteLocksOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildBulkDeleteQueuesOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildBulkPutLocksOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildDeleteAllLocksOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildDeleteAllQueueItemsOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildDeleteLockOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildDeleteQueueItemOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildEnqueueOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetAllLocksOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetConfigurationOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetLockOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueueItemOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueueItemsCountOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueueItemsOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueuesItemsCountOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueuesCountOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueuesOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueuesStatisticsOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildLockedEnqueueOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildPutLockOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildReplaceQueueItemOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildSetConfigurationOperation;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -15,17 +55,14 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.swisspush.redisques.util.RedisquesConfiguration;
 import org.swisspush.redisques.util.Result;
 import org.swisspush.redisques.util.StatusCode;
-
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.swisspush.redisques.util.HttpServerRequestUtil.*;
-import static org.swisspush.redisques.util.RedisquesAPI.*;
 
 /**
  * Handler class for HTTP requests providing access to Redisques over HTTP.
@@ -44,7 +81,6 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
     private static final String CONTENT_TYPE = "content-type";
     private static final String LOCKED_PARAM = "locked";
     private static final String UNLOCK_PARAM = "unlock";
-    private static final String COUNT_PARAM = "count";
     private static final String BULK_DELETE_PARAM = "bulkDelete";
     private static final String EMPTY_QUEUES_PARAM = "emptyQueues";
     private static final String DELETED = "deleted";
@@ -101,6 +137,11 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
          * Get monitor information
          */
         router.get(prefix + "/monitor/").handler(this::getMonitorInformation);
+
+        /*
+         * Get statistic information
+         */
+        router.get(prefix + "/statistics/").handler(this::getQueuesStatistics);
 
         /*
          * Enqueue or LockedEnqueue
@@ -393,19 +434,19 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
 
     private void getQueueItemsCount(RoutingContext ctx) {
         decodedQueueNameOrRespondWithBadRequest(ctx, lastPart(ctx.request().path())).ifPresent(queue ->
-                eventBus.send(redisquesAddress, buildGetQueueItemsCountOperation(queue), (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
-                    if (reply.failed()) {
-                        log.warn("Failed to getQueueItemsCount", reply.cause());
-                        // Continue, only to keep backward compatibility.
-                    }
-                    if (reply.succeeded() && OK.equals(reply.result().body().getString(STATUS))) {
-                        JsonObject result = new JsonObject();
-                        result.put("count", reply.result().body().getLong(VALUE));
-                        jsonResponse(ctx.response(), result);
-                    } else {
-                        respondWith(StatusCode.INTERNAL_SERVER_ERROR, "Error gathering count of active queue items", ctx.request());
-                    }
-                }));
+            eventBus.send(redisquesAddress, buildGetQueueItemsCountOperation(queue), (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
+                if (reply.failed()) {
+                    log.warn("Failed to getQueueItemsCount", reply.cause());
+                    // Continue, only to keep backward compatibility.
+                }
+                if (reply.succeeded() && OK.equals(reply.result().body().getString(STATUS))) {
+                    JsonObject result = new JsonObject();
+                    result.put(COUNT, reply.result().body().getLong(VALUE));
+                    jsonResponse(ctx.response(), result);
+                } else {
+                    respondWith(StatusCode.INTERNAL_SERVER_ERROR, "Error gathering count of active queue items", ctx.request());
+                }
+            }));
     }
 
     private void getConfiguration(RoutingContext ctx) {
@@ -448,26 +489,30 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
     }
 
     private void getMonitorInformation(RoutingContext ctx) {
-        boolean emptyQueues = evaluateUrlParameterToBeEmptyOrTrue(EMPTY_QUEUES_PARAM, ctx.request());
-        final JsonObject resultObject = new JsonObject();
-        final JsonArray queuesArray = new JsonArray();
-        eventBus.send(redisquesAddress, buildGetQueuesOperation(), (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
-            if (reply.failed()) {
-                log.warn("Failed to getMonitorInformation", reply.cause());
-                // Continue, to keep backward compatibility (aka run into NPE).
-            }
+        final boolean emptyQueues = evaluateUrlParameterToBeEmptyOrTrue(EMPTY_QUEUES_PARAM, ctx.request());
+        final int limit = extractLimit(ctx);
+        String filter = ctx.request().params().get(FILTER);
+        eventBus.send(redisquesAddress, buildGetQueuesItemsCountOperation(filter), (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
             if (reply.succeeded() && OK.equals(reply.result().body().getString(STATUS))) {
-                final List<String> queueNames = reply.result().body().getJsonObject(VALUE).getJsonArray("queues").getList();
-                collectQueueLengths(queueNames, extractLimit(ctx), emptyQueues, mapEntries -> {
-                    for (Map.Entry<String, Long> entry : mapEntries) {
-                        JsonObject obj = new JsonObject();
-                        obj.put("name", entry.getKey());
-                        obj.put("size", entry.getValue());
-                        queuesArray.add(obj);
+                JsonArray queuesArray = reply.result().body().getJsonArray(QUEUES);
+                if (queuesArray!=null && !queuesArray.isEmpty()) {
+                    List<JsonObject> queuesList = queuesArray.getList();
+                    queuesList = sortJsonQueueArrayBySize(queuesList);
+                    if (!emptyQueues) {
+                        queuesList = filterJsonQueueArrayNotEmpty(queuesList);
                     }
-                    resultObject.put("queues", queuesArray);
+                    if (limit > 0) {
+                        queuesList = limitJsonQueueArray(queuesList, limit);
+                    }
+                    JsonObject resultObject = new JsonObject();
+                    resultObject.put(QUEUES, queuesList);
                     jsonResponse(ctx.response(), resultObject);
-                });
+                } else {
+                    // there was no result, we as well return an empty result
+                    JsonObject resultObject = new JsonObject();
+                    resultObject.put(QUEUES, new JsonArray());
+                    jsonResponse(ctx.response(), resultObject);
+                }
             } else {
                 String error = "Error gathering names of active queues";
                 log.error(error);
@@ -476,8 +521,10 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
         });
     }
 
+
+
     private void listOrCountQueues(RoutingContext ctx) {
-        if (evaluateUrlParameterToBeEmptyOrTrue(COUNT_PARAM, ctx.request())) {
+        if (evaluateUrlParameterToBeEmptyOrTrue(COUNT, ctx.request())) {
             getQueuesCount(ctx);
         } else {
             listQueues(ctx);
@@ -489,7 +536,7 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
         eventBus.send(redisquesAddress, buildGetQueuesCountOperation(filter), (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
             if (reply.succeeded() && OK.equals(reply.result().body().getString(STATUS))) {
                 JsonObject result = new JsonObject();
-                result.put("count", reply.result().body().getLong(VALUE));
+                result.put(COUNT, reply.result().body().getLong(VALUE));
                 jsonResponse(ctx.response(), result);
             } else {
                 String error = "Error gathering count of active queues. Cause: " + reply.result().body().getString(MESSAGE);
@@ -521,7 +568,7 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
     }
 
     private void listOrCountQueueItems(RoutingContext ctx) {
-        if (evaluateUrlParameterToBeEmptyOrTrue(COUNT_PARAM, ctx.request())) {
+        if (evaluateUrlParameterToBeEmptyOrTrue(COUNT, ctx.request())) {
             getQueueItemsCount(ctx);
         } else {
             listQueueItems(ctx);
@@ -782,42 +829,41 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
         }
     }
 
-    private void collectQueueLengths(final List<String> queueNames, final int limit, final boolean showEmptyQueues, final QueueLengthCollectingCallback callback) {
-        final SortedMap<String, Long> resultMap = new TreeMap<>();
-        final List<Map.Entry<String, Long>> mapEntryList = new ArrayList<>();
-        final AtomicInteger subCommandCount = new AtomicInteger(queueNames.size());
-        if (!queueNames.isEmpty()) {
-            for (final String name : queueNames) {
-                eventBus.send(redisquesAddress, buildGetQueueItemsCountOperation(name), (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
-                    subCommandCount.decrementAndGet();
-                    if (reply.succeeded() && OK.equals(reply.result().body().getString(STATUS))) {
-                        final long count = reply.result().body().getLong(VALUE);
-                        if (showEmptyQueues || count > 0) {
-                            resultMap.put(name, count);
-                        }
-                    } else {
-                        log.error("Error gathering size of queue " + name);
-                    }
-
-                    if (subCommandCount.get() == 0) {
-                        mapEntryList.addAll(resultMap.entrySet());
-                        sortResultMap(mapEntryList);
-                        int toIndex = limit > queueNames.size() ? queueNames.size() : limit;
-                        toIndex = Math.min(mapEntryList.size(), toIndex);
-                        callback.onDone(mapEntryList.subList(0, toIndex));
-                    }
-                });
-            }
-        } else {
-            callback.onDone(mapEntryList);
-        }
-    }
-
-    private interface QueueLengthCollectingCallback {
-        void onDone(List<Map.Entry<String, Long>> mapEntries);
-    }
-
     private void sortResultMap(List<Map.Entry<String, Long>> input) {
         input.sort((left, right) -> right.getValue().compareTo(left.getValue()));
     }
+
+    private List<JsonObject> sortJsonQueueArrayBySize(List<JsonObject> queueList) {
+        queueList.sort((left, right) -> right.getLong("size").compareTo(left.getLong("size")));
+        return queueList;
+    }
+
+    private List<JsonObject> filterJsonQueueArrayNotEmpty(List<JsonObject> queueList) {
+        return queueList.stream()
+            .filter(
+                queue -> queue.getLong("size") > 0)
+            .collect(Collectors.toList());
+    }
+
+    private List<JsonObject> limitJsonQueueArray(List<JsonObject> queueList, int limit) {
+        return queueList.stream().limit(limit).collect(Collectors.toList());
+    }
+
+    private void getQueuesStatistics(RoutingContext ctx) {
+        String filter = ctx.request().params().get(FILTER);
+        final JsonObject resultObject = new JsonObject();
+        eventBus.send(redisquesAddress, buildGetQueuesStatisticsOperation(filter),
+            (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
+                if (reply.succeeded() && OK.equals(reply.result().body().getString(STATUS))) {
+                    JsonArray queuesArray = reply.result().body().getJsonArray(QUEUES);
+                    resultObject.put(QUEUES, queuesArray);
+                    jsonResponse(ctx.response(), resultObject);
+                } else {
+                    String error = "Error gathering names of active queues";
+                    log.error(error);
+                    respondWith(StatusCode.INTERNAL_SERVER_ERROR, error, ctx.request());
+                }
+            });
+    }
+
 }

--- a/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
@@ -400,23 +400,25 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
 
     private void getQueueItemsCount(RoutingContext ctx) {
         decodedQueueNameOrRespondWithBadRequest(ctx, lastPart(ctx.request().path())).ifPresent(queue ->
-                eventBus.request(redisquesAddress, buildGetQueueItemsCountOperation(queue), (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
-                if (reply.failed()) {
-                    log.warn("Failed to getQueueItemsCount", reply.cause());
-                    // Continue, only to keep backward compatibility.
-                }
-                if (reply.succeeded() && OK.equals(reply.result().body().getString(STATUS))) {
-                    JsonObject result = new JsonObject();
-                    result.put(COUNT, reply.result().body().getLong(VALUE));
-                    jsonResponse(ctx.response(), result);
-                } else {
-                    respondWith(StatusCode.INTERNAL_SERVER_ERROR, "Error gathering count of active queue items", ctx.request());
-                }
-            }));
+                eventBus.request(redisquesAddress, buildGetQueueItemsCountOperation(queue),
+                (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
+            if (reply.failed()) {
+                log.warn("Failed to getQueueItemsCount", reply.cause());
+                // Continue, only to keep backward compatibility.
+            }
+            if (reply.succeeded() && OK.equals(reply.result().body().getString(STATUS))) {
+                JsonObject result = new JsonObject();
+                result.put(COUNT, reply.result().body().getLong(VALUE));
+                jsonResponse(ctx.response(), result);
+            } else {
+                respondWith(StatusCode.INTERNAL_SERVER_ERROR, "Error gathering count of active queue items", ctx.request());
+            }
+        }));
     }
 
     private void getConfiguration(RoutingContext ctx) {
-        eventBus.request(redisquesAddress, buildGetConfigurationOperation(), (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
+        eventBus.request(redisquesAddress, buildGetConfigurationOperation(),
+                (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
             if (reply.failed()) {
                 log.warn("Failed to getConfiguration.", reply.cause());
                 // Continue, only to keep backward compatibility.

--- a/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
@@ -400,20 +400,21 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
 
     private void getQueueItemsCount(RoutingContext ctx) {
         decodedQueueNameOrRespondWithBadRequest(ctx, lastPart(ctx.request().path())).ifPresent(queue ->
-                eventBus.request(redisquesAddress, buildGetQueueItemsCountOperation(queue),
-                (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
-            if (reply.failed()) {
-                log.warn("Failed to getQueueItemsCount", reply.cause());
-                // Continue, only to keep backward compatibility.
-            }
-            if (reply.succeeded() && OK.equals(reply.result().body().getString(STATUS))) {
-                JsonObject result = new JsonObject();
-                result.put(COUNT, reply.result().body().getLong(VALUE));
-                jsonResponse(ctx.response(), result);
-            } else {
-                respondWith(StatusCode.INTERNAL_SERVER_ERROR, "Error gathering count of active queue items", ctx.request());
-            }
-        }));
+            eventBus.request(redisquesAddress, buildGetQueueItemsCountOperation(queue),
+                    (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
+                if (reply.failed()) {
+                    log.warn("Failed to getQueueItemsCount", reply.cause());
+                    // Continue, only to keep backward compatibility.
+                }
+                if (reply.succeeded() && OK.equals(reply.result().body().getString(STATUS))) {
+                    JsonObject result = new JsonObject();
+                    result.put(COUNT, reply.result().body().getLong(VALUE));
+                    jsonResponse(ctx.response(), result);
+                } else {
+                    respondWith(StatusCode.INTERNAL_SERVER_ERROR, "Error gathering count of active queue items", ctx.request());
+                }
+            })
+        );
     }
 
     private void getConfiguration(RoutingContext ctx) {

--- a/src/main/java/org/swisspush/redisques/lua/LuaScript.java
+++ b/src/main/java/org/swisspush/redisques/lua/LuaScript.java
@@ -1,7 +1,8 @@
 package org.swisspush.redisques.lua;
 
 public enum LuaScript {
-    CHECK("redisques_check.lua");
+    CHECK("redisques_check.lua"),
+    MLLEN( "redisques_mllen.lua");
 
     private String file;
 

--- a/src/main/java/org/swisspush/redisques/lua/LuaScriptManager.java
+++ b/src/main/java/org/swisspush/redisques/lua/LuaScriptManager.java
@@ -24,6 +24,11 @@ public class LuaScriptManager {
         LuaScriptState luaGetScriptState = new LuaScriptState(LuaScript.CHECK, redisClient);
         luaGetScriptState.loadLuaScript(new RedisCommandDoNothing(), 0);
         luaScripts.put(LuaScript.CHECK, luaGetScriptState);
+
+        // load the MultiListLength Lua Script
+        LuaScriptState luaMllenScriptState = new LuaScriptState(LuaScript.MLLEN, redisClient);
+        luaMllenScriptState.loadLuaScript(new RedisCommandDoNothing(), 0);
+        luaScripts.put(LuaScript.MLLEN, luaMllenScriptState);
     }
 
     /**
@@ -87,4 +92,52 @@ public class LuaScriptManager {
             });
         }
     }
+
+
+    public void handleMultiListLength(List<String> keys, Handler<List<Long>> handler){
+        executeRedisCommand(new MultiListLength(keys, redisClient, handler), 0);
+    }
+
+    private class MultiListLength implements RedisCommand {
+
+        private List<String> keys;
+        private Handler<List<Long>> handler;
+        private RedisClient redisClient;
+
+        public MultiListLength(List<String> keys, RedisClient redisClient, final Handler<List<Long>> handler) {
+            this.keys = keys;
+            this.redisClient = redisClient;
+            this.handler = handler;
+        }
+
+        @Override
+        public void exec(int executionCounter) {
+            if (keys==null || keys.isEmpty()){
+                handler.handle(List.of());
+                return;
+            }
+            redisClient.evalsha(luaScripts.get(LuaScript.MLLEN).getSha(), keys, List.of(), event -> {
+                if(event.succeeded()){
+                    List<Long> res = event.result().getList();
+                    handler.handle(res);
+                } else {
+                    String message = event.cause().getMessage();
+                    if(message != null && message.startsWith("NOSCRIPT")) {
+                        log.warn("MultiListLength script couldn't be found, reload it");
+                        log.warn("amount the script got loaded: " + String.valueOf(executionCounter));
+                        if(executionCounter > 10) {
+                            log.error("amount the MultiListLength script got loaded is higher than 10, we abort");
+                        } else {
+                            luaScripts.get(LuaScript.MLLEN).loadLuaScript(new MultiListLength(keys, redisClient, handler), executionCounter);
+                        }
+                    } else {
+                        log.error("ListLength request failed.", event.cause());
+                    }
+                    event.failed();
+                }
+            });
+        }
+    }
+
+
 }

--- a/src/main/java/org/swisspush/redisques/lua/LuaScriptManager.java
+++ b/src/main/java/org/swisspush/redisques/lua/LuaScriptManager.java
@@ -133,7 +133,7 @@ public class LuaScriptManager {
                     String message = event.cause().getMessage();
                     if(message != null && message.startsWith("NOSCRIPT")) {
                         log.warn("MultiListLength script couldn't be found, reload it");
-                        log.warn("amount the script got loaded: " + String.valueOf(executionCounter));
+                        log.warn("amount the script got loaded: {}", String.valueOf(executionCounter));
                         if(executionCounter > 10) {
                             log.error("amount the MultiListLength script got loaded is higher than 10, we abort");
                         } else {

--- a/src/main/java/org/swisspush/redisques/util/HttpServerRequestUtil.java
+++ b/src/main/java/org/swisspush/redisques/util/HttpServerRequestUtil.java
@@ -1,15 +1,18 @@
 package org.swisspush.redisques.util;
 
+import static org.swisspush.redisques.util.RedisquesAPI.PAYLOAD;
+
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-
 import java.nio.charset.Charset;
-
-import static org.swisspush.redisques.util.RedisquesAPI.PAYLOAD;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
 
 /**
  * Util class to work with {@link HttpServerRequest}s
@@ -145,4 +148,5 @@ public class HttpServerRequestUtil {
         }
         return object.toString();
     }
+
 }

--- a/src/main/java/org/swisspush/redisques/util/QueueHandlerUtil.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueHandlerUtil.java
@@ -1,14 +1,9 @@
 package org.swisspush.redisques.util;
 
-import static org.swisspush.redisques.util.RedisquesAPI.PAYLOAD;
-
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import java.nio.charset.Charset;
+import io.vertx.redis.client.Response;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -25,19 +20,19 @@ public class QueueHandlerUtil {
      * @return The resulting filtered list of queues. If there is no filter given, the full list
      *         of queues is returned.
      */
-    public static List<String> filterQueues(JsonArray allQueues, Optional<Pattern> filterPattern) {
+    public static List<String> filterQueues(Response allQueues, Optional<Pattern> filterPattern) {
         List<String> queues = new ArrayList<>();
         if (filterPattern != null && filterPattern.isPresent()) {
             Pattern pattern = filterPattern.get();
             for (int i = 0; i < allQueues.size(); i++) {
-                String queue = allQueues.getString(i);
+                String queue = allQueues.get(i).toString();
                 if (pattern.matcher(queue).find()) {
                     queues.add(queue);
                 }
             }
         } else {
             for (int i = 0; i < allQueues.size(); i++) {
-                queues.add(allQueues.getString(i));
+                queues.add(allQueues.get(i).toString());
             }
         }
         return queues;

--- a/src/main/java/org/swisspush/redisques/util/QueueHandlerUtil.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueHandlerUtil.java
@@ -1,6 +1,5 @@
 package org.swisspush.redisques.util;
 
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.redis.client.Response;

--- a/src/main/java/org/swisspush/redisques/util/QueueHandlerUtil.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueHandlerUtil.java
@@ -1,0 +1,46 @@
+package org.swisspush.redisques.util;
+
+import static org.swisspush.redisques.util.RedisquesAPI.PAYLOAD;
+
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+public class QueueHandlerUtil {
+
+    private static final Logger log = LoggerFactory.getLogger(QueueHandlerUtil.class);
+
+    /**
+     * Apply the given filter pattern to the given JsonArray containing the list of queues.
+     * @param allQueues list of JSON objects containing the queueName to be filtered
+     * @param filterPattern The filter regex pattern to be matched against the given queues list
+     * @return The resulting filtered list of queues. If there is no filter given, the full list
+     *         of queues is returned.
+     */
+    public static List<String> filterQueues(JsonArray allQueues, Optional<Pattern> filterPattern) {
+        List<String> queues = new ArrayList<>();
+        if (filterPattern != null && filterPattern.isPresent()) {
+            Pattern pattern = filterPattern.get();
+            for (int i = 0; i < allQueues.size(); i++) {
+                String queue = allQueues.getString(i);
+                if (pattern.matcher(queue).find()) {
+                    queues.add(queue);
+                }
+            }
+        } else {
+            for (int i = 0; i < allQueues.size(); i++) {
+                queues.add(allQueues.getString(i));
+            }
+        }
+        return queues;
+    }
+
+}

--- a/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
@@ -1,9 +1,6 @@
 package org.swisspush.redisques.util;
 
-import static org.swisspush.redisques.util.RedisquesAPI.ERROR;
-import static org.swisspush.redisques.util.RedisquesAPI.OK;
-import static org.swisspush.redisques.util.RedisquesAPI.QUEUENAME;
-import static org.swisspush.redisques.util.RedisquesAPI.STATUS;
+import static org.swisspush.redisques.util.RedisquesAPI.*;
 
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonArray;
@@ -271,11 +268,11 @@ public class QueueStatisticsCollector {
 
         JsonObject getAsJsonObject() {
             return new JsonObject()
-                .put("name", queueName)
-                .put("size", size)
-                .put("failures", failures)
-                .put("backpressureTime", backpressureTime)
-                .put("slowdownTime", slowdownTime);
+                .put(MONITOR_QUEUE_NAME, queueName)
+                .put(MONITOR_QUEUE_SIZE, size)
+                .put(STATISTIC_QUEUE_FAILURES, failures)
+                .put(STATISTIC_QUEUE_BACKPRESSURE, backpressureTime)
+                .put(STATISTIC_QUEUE_SLOWDOWN, slowdownTime);
         }
     }
 

--- a/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
@@ -105,12 +105,13 @@ public class QueueStatisticsCollector {
      * @return The new value of the counter after the incrementation.
      */
     public long incrementQueueFailureCount(String queueName) {
-        AtomicLong failureCount = queueFailureCount.putIfAbsent(queueName, new AtomicLong(1));
-        updateStatisticsInRedis(queueName);
+        long newFailureCount = 1;
+        AtomicLong failureCount = queueFailureCount.putIfAbsent(queueName, new AtomicLong(newFailureCount));
         if (failureCount != null) {
-            return failureCount.addAndGet(1);
+            newFailureCount = failureCount.addAndGet(1);
         }
-        return 1;
+        updateStatisticsInRedis(queueName);
+        return newFailureCount;
     }
 
     /**
@@ -336,7 +337,7 @@ public class QueueStatisticsCollector {
                     String queueName = jObj.getString(RedisquesAPI.QUEUENAME);
                     QueueStatistic queueStatistic = statisticsMap.get(queueName);
                     if (queueStatistic != null) {
-                        // if it isn't there, there was obviously no statistic available for this
+                        // if it isn't there, there is obviously no statistic needed
                         queueStatistic.setFailures(jObj.getLong(QUEUE_FAILURES, 0L));
                         queueStatistic.setBackpressureTime(jObj.getLong(QUEUE_BACKPRESSURE, 0L));
                         queueStatistic.setSlowdownTime(jObj.getLong(QUEUE_SLOWDOWNTIME, 0L));

--- a/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
@@ -330,7 +330,7 @@ public class QueueStatisticsCollector {
                 }
                 // put the received statistics data to the former prepared statistics objects
                 // per queue
-                Iterator<Response> itr = statisticsSet.result().stream().iterator();
+                Iterator<Response> itr = statisticsSet.result().iterator();
                 while (itr.hasNext()){
                     JsonObject jObj = new JsonObject(itr.next().toString());
                     String queueName = jObj.getString(RedisquesAPI.QUEUENAME);
@@ -345,8 +345,7 @@ public class QueueStatisticsCollector {
                 // build the final resulting statistics list from the former merged queue
                 // values from various sources
                 JsonArray result = new JsonArray();
-                for (int i = 0; i < queues.size(); i++) {
-                    String queueName = queues.get(i);
+                for (String queueName: queues) {
                     QueueStatistic stats = statisticsMap.get(queueName);
                     if (stats != null) {
                         result.add(stats.getAsJsonObject());

--- a/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
@@ -51,7 +51,7 @@ public class QueueStatisticsCollector {
     private final String queuePrefix;
 
     public QueueStatisticsCollector(RedisAPI redisAPI, LuaScriptManager luaScriptManager,
-        String queuePrefix) {
+            String queuePrefix) {
         this.redisAPI = redisAPI;
         this.luaScriptManager = luaScriptManager;
         this.queuePrefix = queuePrefix;

--- a/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
@@ -1,0 +1,365 @@
+package org.swisspush.redisques.util;
+
+import static org.swisspush.redisques.util.RedisquesAPI.ERROR;
+import static org.swisspush.redisques.util.RedisquesAPI.OK;
+import static org.swisspush.redisques.util.RedisquesAPI.QUEUENAME;
+import static org.swisspush.redisques.util.RedisquesAPI.STATUS;
+
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.redis.RedisClient;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import org.swisspush.redisques.lua.LuaScriptManager;
+
+/**
+ * Class StatisticsCollector helps collecting statistics information about queue handling and
+ * failures.
+ * <p>
+ * Due to the fact that there is a Redisques responsible for a queue in a cluster, we could assume
+ * that the values are good enough when cached locally for queue processing only.  If the
+ * responsible Redisques Instance changes it will build up the statistics straight away by itself
+ * anyway.
+ * <p>
+ * But in the case or the stattistics read operation, we must get the statistics of all queues
+ * existing, not only the ones which are treated by the redisques instance (there might be multiple
+ * involved). Therefore, we must write the statistics values as well to redis and retrieve them from
+ * there once needed. Note that the statistics is written asynch and only in the case of queue
+ * failures, therefore it shouldn't happen too often.
+ */
+public class QueueStatisticsCollector {
+
+    private static final Logger log = LoggerFactory.getLogger(QueueStatisticsCollector.class);
+
+    private static final String STATSKEY = "redisques:stats";
+    private final static String QUEUE_FAILURES = "failures";
+    private final static String QUEUE_BACKPRESSURE = "backpressureTime";
+    private final static String QUEUE_SLOWDOWNTIME = "slowdownTime";
+
+    private final Map<String, AtomicLong> queueFailureCount = new HashMap<>();
+    private final Map<String, Long> queueBackpressureTime = new HashMap<>();
+    private final Map<String, Long> queueSlowDownTime = new HashMap<>();
+
+    private final RedisClient redisClient;
+    private final LuaScriptManager luaScriptManager;
+    private final String queuePrefix;
+
+    public QueueStatisticsCollector(RedisClient redisClient, LuaScriptManager luaScriptManager,
+        String queuePrefix) {
+        this.redisClient = redisClient;
+        this.luaScriptManager = luaScriptManager;
+        this.queuePrefix = queuePrefix;
+    }
+
+    /**
+     * Does reset all statistics values of the given queue. In memory but as well the persisted
+     * ones in redis.
+     *
+     * Note: The reset is only executed on the persisted statistics data if there is really
+     * a need for.
+     *
+     * @param queueName The queue name for which the statistic values must be reset.
+     */
+    public void resetQueueStatistics(String queueName) {
+        AtomicLong failureCount = queueFailureCount.get(queueName);
+        queueFailureCount.remove(queueName);
+        queueSlowDownTime.remove(queueName);
+        queueBackpressureTime.remove(queueName);
+        if (failureCount != null && failureCount.get()>0) {
+          // there was a real failure, therefore we will execute this
+          // cleanup as well on Redis itself as we would like to do redis operations
+          // only if necessary of course.
+          updateStatisticsInRedis(queueName);
+        }
+    }
+
+    /**
+     * Does reset all statistics values of all given queues. In memory but as well the persisted
+     * ones in redis.
+     * @param queues The list of queue names for which the statistic values must be reset.
+     */
+    public void resetQueueStatistics(JsonArray queues) {
+        if (queues == null) {
+            return;
+        }
+        final int size = queues.size();
+        List<String> queueKeys = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            resetQueueStatistics(queues.getString(i));
+        }
+    }
+
+    /**
+     * Increments the failure counter for the given queue by 1.
+     *
+     * Note: There is explicitely no decrement operation foreseen because once a queue
+     * is operable again, it will reset the failure counter immediately to 0. Therefore only the
+     * reset operation is needed in general.
+     *
+     * @param queueName The name of the queue for which the incrementation must be done.
+     * @return The new value of the counter after the incrementation.
+     */
+    public long incrementQueueFailureCount(String queueName) {
+        AtomicLong failureCount = queueFailureCount.putIfAbsent(queueName, new AtomicLong(1));
+        updateStatisticsInRedis(queueName);
+        if (failureCount != null) {
+            return failureCount.addAndGet(1);
+        }
+        return 1;
+    }
+
+    /**
+     * Retrieves the current failure count we have in memory for this redisques instance (there
+     * might be more than one in use).
+     *
+     * Note: Because each queue is associated resp. registered with a certain redisques instance, it
+     * is valid to read this value just from our own memory only and no redis interaction takes
+     * place.
+     *
+     * @param queueName The queue name for which we want to retrieve the current failure count
+     * @return The evaluated failure count for the given queue name
+     */
+    public long getQueueFailureCount(String queueName) {
+        AtomicLong count = queueFailureCount.get(queueName);
+        if (count != null) {
+            return count.longValue();
+        }
+        return 0;
+    }
+
+    /**
+     * Set the statistics backpressure time to the given value. Note that this is done in memory
+     * but as well persisted on redis.
+     * @param queueName The name of the queue for which the value must be set.
+     * @param time The backpressure time in ms
+     */
+    public void setQueueBackPressureTime(String queueName, long time) {
+        if (time > 0) {
+            queueBackpressureTime.put(queueName, time);
+            updateStatisticsInRedis(queueName);
+        } else {
+            Long lastTime = queueBackpressureTime.remove(queueName);
+            if (lastTime!=null){
+                updateStatisticsInRedis(queueName);
+            }
+        }
+    }
+
+    /**
+     * Retrieves the current used backpressure time we have in memory for this redisques instance.
+     *
+     * Note: Because each queue is associated resp. registered with a certain redisques instance, it
+     * is valid to read this value just from our own memory only and no redis interaction takes
+     * place.
+     *
+     * @param queueName The queue name for which we want to retrieve the current failure count
+     * @return The evaluated failure count for the given queue name
+     */
+    private long getQueueBackPressureTime(String queueName) {
+        return queueBackpressureTime.getOrDefault(queueName, 0L);
+    }
+
+    /**
+     * Set the statistics slowdown time to the given value. Note that this is done in memory
+     * but as well persisted on redis.
+     * @param queueName The name of the queue for which the value must be set.
+     * @param time The slowdown time in ms
+     */
+    public void setQueueSlowDownTime(String queueName, long time) {
+        if (time > 0) {
+            queueSlowDownTime.put(queueName, time);
+            updateStatisticsInRedis(queueName);
+        } else {
+            Long lastTime = queueSlowDownTime.remove(queueName);
+            if (lastTime!=null){
+                updateStatisticsInRedis(queueName);
+            }
+        }
+    }
+
+    /**
+     * Retrieves the current used slowdown time we have in memory for this redisques instance.
+     *
+     * Note: Because each queue is associated resp. registered with a certain redisques instance, it
+     * is valid to read this value just from our own memory only and no redis interaction takes
+     * place.
+     *
+     * @param queueName The queue name for which we want to retrieve the current failure count
+     * @return The evaluated failure count for the given queue name
+     */
+    private long getQueueSlowDownTime(String queueName) {
+        return queueSlowDownTime.getOrDefault(queueName, 0L);
+    }
+
+    /**
+     * Write all the collected statistics for the given Queue to
+     * redis for later usage if somebody requests the queue statistics.
+     * If there are no valid useful data available eg. all 0, the corresponding
+     * statistics entry is removed from redis
+     */
+    private void updateStatisticsInRedis(String queueName) {
+        long failures = getQueueFailureCount(queueName);
+        long slowDownTime = getQueueSlowDownTime(queueName);
+        long backpressureTime = getQueueBackPressureTime(queueName);
+        if (failures > 0 || slowDownTime > 0 && backpressureTime > 0) {
+            JsonObject obj = new JsonObject();
+            obj.put(QUEUENAME, queueName);
+            obj.put(QUEUE_FAILURES, failures);
+            obj.put(QUEUE_SLOWDOWNTIME, slowDownTime);
+            obj.put(QUEUE_BACKPRESSURE, backpressureTime);
+            redisClient.hset(STATSKEY, queueName, obj.toString(), emptyHandler -> {
+            });
+        } else {
+            redisClient.hdel(STATSKEY, queueName, emptyHandler -> {
+            });
+        }
+    }
+
+    /**
+     * An internally used class for statistics value storage per queue.
+     */
+    private class QueueStatistic {
+
+        private final String queueName;
+        private long size;
+        private long failures;
+        private long backpressureTime;
+        private long slowdownTime;
+
+        QueueStatistic(String queueName) {
+            this.queueName = queueName;
+        }
+
+        void setSize(Long size) {
+            if (size != null && size >= 0) {
+                this.size = size;
+                return;
+            }
+            this.size = 0;
+        }
+
+        void setFailures(Long failures) {
+            if (failures != null && failures >= 0) {
+                this.failures = failures;
+                return;
+            }
+            this.failures = 0;
+        }
+
+        void setBackpressureTime(Long backpressureTime) {
+            if (backpressureTime != null && backpressureTime >= 0) {
+                this.backpressureTime = backpressureTime;
+                return;
+            }
+            this.backpressureTime = 0;
+        }
+
+        void setSlowdownTime(Long slowdownTime) {
+            if (slowdownTime != null && slowdownTime >= 0) {
+                this.slowdownTime = slowdownTime;
+                return;
+            }
+            this.slowdownTime = 0;
+        }
+
+        JsonObject getAsJsonObject() {
+            return new JsonObject()
+                .put("name", queueName)
+                .put("size", size)
+                .put("failures", failures)
+                .put("backpressureTime", backpressureTime)
+                .put("slowdownTime", slowdownTime);
+        }
+    }
+
+
+    /**
+     * Retrieve the queue statistics for the requested queues.
+     *
+     * Note: This operation does interact with Redis to retrieve the values for the statistics
+     * for all queues requested (independent of the redisques instance for which the queues are
+     * registered). Therefore this method must be used with care and not be called too often!
+     *
+     * @param event  The event on which we will answer finally
+     * @param queues The queues for which we are interested in the statistics
+     */
+    public void getQueueStatistics(Message<JsonObject> event, final List<String> queues) {
+        if (queues == null || queues.isEmpty()) {
+            log.debug("Queue statistics evaluation with empty queues, returning empty result");
+            event.reply(new JsonObject().put(STATUS, OK).put(RedisquesAPI.QUEUES, new JsonArray()));
+            return;
+        }
+        // first retrieve all queue sizes from the queues itself by help of the LUA script
+        // which returns for each requested queueName the corresponding queue size.
+        // Note: If a queue doesn't exists, it will anyway return 0 for the same, therefore
+        //       the size of the returned queues must be equal in any case and has the same
+        //       order as the requested queues.
+        List<String> queueKeys = new ArrayList<>();
+        for (String queue : queues){
+            queueKeys.add(this.queuePrefix + queue);
+        }
+        luaScriptManager.handleMultiListLength(queueKeys, queueListLength -> {
+            if (queueListLength == null) {
+                log.error("Unexepected queue MultiListLength result null");
+                event.reply(new JsonObject().put(STATUS, ERROR));
+                return;
+            }
+            if (queueListLength.size() != queues.size()) {
+                log.error("Unexpected queue MultiListLength result with unequal size {} : {}",
+                    queues.size(), queueListLength.size());
+                event.reply(new JsonObject().put(STATUS, ERROR));
+                return;
+            }
+            // populate the list of queue statistics in a Hashmap for later fast merging
+            final HashMap<String, QueueStatistic> statisticsMap = new HashMap<>();
+            for (int i = 0; i < queues.size(); i++) {
+                QueueStatistic qs = new QueueStatistic(queues.get(i));
+                qs.setSize(queueListLength.get(i));
+                statisticsMap.put(qs.queueName, qs);
+            }
+            // now retrieve all available statistics from Redis and merge them
+            // together with the previous populated queue statistics map
+            redisClient.hvals(STATSKEY, statisticsSet -> {
+                if (statisticsSet == null) {
+                    log.error("Unexepected statistics queue evaluation result result null");
+                    event.reply(new JsonObject().put(STATUS, ERROR));
+                    return;
+                }
+                // put the received statistics data to the former prepared statistics objects
+                // per queue
+                List<String> statistics = statisticsSet.result().getList();
+                for (String jStr : statistics) {
+                    JsonObject jObj = new JsonObject(jStr);
+                    String queueName = jObj.getString(RedisquesAPI.QUEUENAME);
+                    QueueStatistic queueStatistic = statisticsMap.get(queueName);
+                    if (queueStatistic != null) {
+                        // if it isn't there, there was obviously no statistic available for this
+                        queueStatistic.setFailures(jObj.getLong(QUEUE_FAILURES, 0L));
+                        queueStatistic.setBackpressureTime(jObj.getLong(QUEUE_BACKPRESSURE, 0L));
+                        queueStatistic.setSlowdownTime(jObj.getLong(QUEUE_SLOWDOWNTIME, 0L));
+                    }
+                }
+                // build the final resulting statistics list from the former merged queue
+                // values from various sources
+                JsonArray result = new JsonArray();
+                for (int i = 0; i < queues.size(); i++) {
+                    String queueName = queues.get(i);
+                    QueueStatistic stats = statisticsMap.get(queueName);
+                    if (stats != null) {
+                        result.add(stats.getAsJsonObject());
+                    }
+                }
+                event.reply(new JsonObject().put(RedisquesAPI.STATUS, RedisquesAPI.OK)
+                    .put(RedisquesAPI.QUEUES, result));
+            });
+        });
+    }
+
+
+}

--- a/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
+++ b/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
@@ -1,9 +1,14 @@
 package org.swisspush.redisques.util;
 
+import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
 
 /**
  * Class RedisquesAPI listing the operations and response values which are supported in Redisques.
@@ -62,7 +67,9 @@ public class RedisquesAPI {
         bulkDeleteLocks(null),
         getQueues(null),
         getQueuesCount(null),
-        getQueueItemsCount(null);
+        getQueueItemsCount(null),
+        getQueuesItemsCount(null),
+        getQueuesStatistics(null);
 
         private final String legacyName;
 
@@ -174,22 +181,32 @@ public class RedisquesAPI {
     }
 
     /**
+     * Evaluate the size of all queues matching the optional given filter pattern.
+     *
      * @param filterPattern
      *      Filter pattern. Method handles {@code null} gracefully.
      */
     public static JsonObject buildGetQueuesCountOperation(String filterPattern) {
-        if (filterPattern != null) {
-            return buildOperation(QueueOperation.getQueuesCount, new JsonObject().put(FILTER, filterPattern));
-        } else {
-            return buildOperation(QueueOperation.getQueuesCount);
-        }
+        return buildOperation(QueueOperation.getQueuesCount, new JsonObject().put(FILTER, filterPattern));
     }
 
+    /**
+     * Evaluate the size of the given queue
+     * @param queueName the name of the queue to be evaluated
+     * @return the evaluated size
+     */
     public static JsonObject buildGetQueueItemsCountOperation(String queueName){
         return buildOperation(QueueOperation.getQueueItemsCount, new JsonObject().put(QUEUENAME, queueName));
     }
 
-    public static JsonObject buildGetLockOperation(String queueName){
+    /**
+     * Evaluate the size of the ques according to the given filter
+     */
+    public static JsonObject buildGetQueuesItemsCountOperation(String filter){
+        return buildOperation(QueueOperation.getQueuesItemsCount, new JsonObject().put(FILTER, filter));
+    }
+
+     public static JsonObject buildGetLockOperation(String queueName){
         return buildOperation(QueueOperation.getLock, new JsonObject().put(QUEUENAME, queueName));
     }
 
@@ -228,4 +245,20 @@ public class RedisquesAPI {
             return buildGetAllLocksOperation();
         }
     }
+
+    public static JsonObject buildGetQueuesStatisticsOperation() {
+        return buildOperation(QueueOperation.getQueuesStatistics);
+    }
+
+    /**
+     * @param filterPattern
+     *      Filter pattern. Method handles {@code null} gracefully.
+     */
+    public static JsonObject buildGetQueuesStatisticsOperation(String filterPattern) {
+        if (filterPattern != null) {
+            return buildOperation(QueueOperation.getQueuesStatistics, new JsonObject().put(FILTER, filterPattern));
+        }
+        return buildGetQueuesStatisticsOperation();
+    }
+
 }

--- a/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
+++ b/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
@@ -1,14 +1,9 @@
 package org.swisspush.redisques.util;
 
-import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.regex.Pattern;
 
 /**
  * Class RedisquesAPI listing the operations and response values which are supported in Redisques.

--- a/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
+++ b/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
@@ -41,6 +41,13 @@ public class RedisquesAPI {
     public static final String NO_SUCH_LOCK = "No such lock";
     public static final String PROCESSOR_DELAY_MAX = "processorDelayMax";
 
+    public static final String MONITOR_QUEUE_NAME = "name";
+    public static final String MONITOR_QUEUE_SIZE = "size";
+    public static final String STATISTIC_QUEUE_FAILURES = "failures";
+    public static final String STATISTIC_QUEUE_BACKPRESSURE = "backpressureTime";
+    public static final String STATISTIC_QUEUE_SLOWDOWN = "slowdownTime";
+
+
     private static Logger log = LoggerFactory.getLogger(RedisquesAPI.class);
 
     public enum QueueOperation {

--- a/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
+++ b/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
@@ -178,19 +178,26 @@ public class RedisquesAPI {
         }
     }
 
+    /**
+     * Evaluate the size of all queues matching the optional given filter pattern.
+     */
     public static JsonObject buildGetQueuesCountOperation(){
         return buildOperation(QueueOperation.getQueuesCount);
     }
 
     /**
      * Evaluate the size of all queues matching the optional given filter pattern.
-     *
      * @param filterPattern
      *      Filter pattern. Method handles {@code null} gracefully.
      */
     public static JsonObject buildGetQueuesCountOperation(String filterPattern) {
-        return buildOperation(QueueOperation.getQueuesCount, new JsonObject().put(FILTER, filterPattern));
+        if (filterPattern != null) {
+            return buildOperation(QueueOperation.getQueuesCount, new JsonObject().put(FILTER, filterPattern));
+        } else {
+            return buildOperation(QueueOperation.getQueuesCount);
+        }
     }
+
 
     /**
      * Evaluate the size of the given queue

--- a/src/main/resources/redisques_mllen.lua
+++ b/src/main/resources/redisques_mllen.lua
@@ -1,0 +1,5 @@
+local result={ }
+for i=1, #KEYS, 1 do
+    result[i] = redis.call("llen",KEYS[i])
+end
+return result

--- a/src/test/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandlerTest.java
+++ b/src/test/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandlerTest.java
@@ -2063,7 +2063,7 @@ public class RedisquesHttpRequestHandlerTest extends AbstractTestCase {
         {   // note: we do it a second time as it seems to be some optimising/caching applied
             // on first time within Redis. Second one is much faster.
             long timestamp = System.currentTimeMillis();
-            response = given().when().when().get("/queuing/statistics").then().assertThat()
+            response = given().when().get("/queuing/statistics").then().assertThat()
                 .statusCode(200).extract().path("queues");
             assert (response.size() == 0);
             statisticsReferenceTime = System.currentTimeMillis() - timestamp;
@@ -2072,7 +2072,7 @@ public class RedisquesHttpRequestHandlerTest extends AbstractTestCase {
 
         {
             long timestamp = System.currentTimeMillis();
-            response = given().when().when().get("/queuing/monitor").then().assertThat()
+            response = given().when().get("/queuing/monitor").then().assertThat()
                 .statusCode(200).extract().path("queues");
             assert (response.size() == 0);
             long monitorTime = System.currentTimeMillis() - timestamp;
@@ -2081,7 +2081,7 @@ public class RedisquesHttpRequestHandlerTest extends AbstractTestCase {
 
         {
             long timestamp = System.currentTimeMillis();
-            response = given().when().when().get("/queuing/monitor").then().assertThat()
+            response = given().when().get("/queuing/monitor").then().assertThat()
                 .statusCode(200).extract().path("queues");
             assert (response.size() == 0);
             monitoringReferenceTime = System.currentTimeMillis() - timestamp;
@@ -2113,7 +2113,7 @@ public class RedisquesHttpRequestHandlerTest extends AbstractTestCase {
 
         {   // first run to warm up the system
             long timestamp = System.currentTimeMillis();
-            response = given().when().when().get("/queuing/monitor").then().assertThat()
+            response = given().when().get("/queuing/monitor").then().assertThat()
                 .statusCode(200).extract().path("queues");
             assert (response.size() == 1000);
             long monitorTime = System.currentTimeMillis() - timestamp;
@@ -2122,7 +2122,7 @@ public class RedisquesHttpRequestHandlerTest extends AbstractTestCase {
 
         {   // redo a second time in order to have any caching/optimizing stuff in place
             long timestamp = System.currentTimeMillis();
-            response = given().when().when().get("/queuing/monitor").then().assertThat()
+            response = given().when().get("/queuing/monitor").then().assertThat()
                 .statusCode(200).extract().path("queues");
             assert (response.size() == 1000);
             long monitorTime = System.currentTimeMillis() - timestamp;
@@ -2135,7 +2135,7 @@ public class RedisquesHttpRequestHandlerTest extends AbstractTestCase {
 
         {   // first run to warm up the system
             long timestamp = System.currentTimeMillis();
-            response = given().when().when().get("/queuing/statistics").then().assertThat()
+            response = given().when().get("/queuing/statistics").then().assertThat()
                 .statusCode(200).extract().path("queues");
             assert (response.size() == 1000);
             long statisticsTime = System.currentTimeMillis() - timestamp;
@@ -2144,7 +2144,7 @@ public class RedisquesHttpRequestHandlerTest extends AbstractTestCase {
 
         {   // redo a second time in order to have any caching/optimizing stuff in place
             long timestamp = System.currentTimeMillis();
-            response = given().when().when().get("/queuing/statistics").then().assertThat()
+            response = given().when().get("/queuing/statistics").then().assertThat()
                 .statusCode(200).extract().path("queues");
             assert (response.size() == 1000);
             long statisticsTime = System.currentTimeMillis() - timestamp;

--- a/src/test/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandlerTest.java
+++ b/src/test/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandlerTest.java
@@ -2112,8 +2112,8 @@ public class RedisquesHttpRequestHandlerTest extends AbstractTestCase {
             assert (response.size() == 1000);
             long monitorTime = System.currentTimeMillis() - timestamp;
             System.out.println("Monitoring time=" + monitorTime);
-            // assume that the used time is smaller than  10 times the reference times
-            assert (monitorTime < 10 * monitoringReferenceTime);
+            // assume that the used time is smaller than  xx times the reference times
+            assert (monitorTime < 20 * monitoringReferenceTime);
         }
 
         System.out.println("-------------------- STATISTICS CHECK PHASE -------------------------");
@@ -2134,8 +2134,8 @@ public class RedisquesHttpRequestHandlerTest extends AbstractTestCase {
             assert (response.size() == 1000);
             long statisticsTime = System.currentTimeMillis() - timestamp;
             System.out.println("Statistics time=" + statisticsTime);
-            // assume that the used time is smaller than  10 times the reference times
-            assert (statisticsTime < 10 * statisticsReferenceTime);
+            // assume that the used time is smaller than  xx times the reference times
+            assert (statisticsTime < 20 * statisticsReferenceTime);
         }
 
         System.out.println("------------------ PERFORMANCE CHECKS COMPLETED ---------------------");

--- a/src/test/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandlerTest.java
+++ b/src/test/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandlerTest.java
@@ -2040,8 +2040,8 @@ public class RedisquesHttpRequestHandlerTest extends AbstractTestCase {
         async.complete();
     }
 
-    @Test(timeout = 10000L)
-    //@Ignore
+    @Test(timeout = 15000L)
+    @Ignore
     public void testPerformance(TestContext context) throws Exception {
         Async async = context.async();
         ArrayList<HashMap<String, Object>> response;

--- a/src/test/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandlerTest.java
+++ b/src/test/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandlerTest.java
@@ -2041,7 +2041,7 @@ public class RedisquesHttpRequestHandlerTest extends AbstractTestCase {
     }
 
     @Test(timeout = 10000L)
-    @Ignore
+    //@Ignore
     public void testPerformance(TestContext context) throws Exception {
         Async async = context.async();
         ArrayList<HashMap<String, Object>> response;

--- a/src/test/java/org/swisspush/redisques/slowdown/EnqueueThrottleTest.java
+++ b/src/test/java/org/swisspush/redisques/slowdown/EnqueueThrottleTest.java
@@ -71,7 +71,7 @@ public class EnqueueThrottleTest {
     }
 
     @Test
-    public void testEnqueuThrottling(TestContext testContext) {
+    public void testEnqueueThrottling(TestContext testContext) {
         Async async = testContext.async();
         sendAMessage(testContext);
         Vertx vertx = RULE.vertx();
@@ -86,7 +86,7 @@ public class EnqueueThrottleTest {
     private void sendAMessage(TestContext testContext) {
         int num = queueMirror.size();
         if (num == 6) { // the 5th and 6th message (Hallo-4 and Hallo-5) reach "enqueueMaxDelayMillis" - don't need more
-            System.out.println("All messages enqueued - will now allow Processor to conume successfully");
+            System.out.println("All messages enqueued - will now allow Processor to consume successfully");
             blockProcessor = false;
             return;
         }

--- a/src/test/java/org/swisspush/redisques/util/RedisquesAPITest.java
+++ b/src/test/java/org/swisspush/redisques/util/RedisquesAPITest.java
@@ -295,6 +295,24 @@ public class RedisquesAPITest {
         context.assertEquals(expected, operation);
     }
 
+    @Test
+    public void testBuildGetQueuesStatisticsOperation(TestContext context) throws Exception {
+
+        JsonObject operation = RedisquesAPI.buildGetQueuesStatisticsOperation();
+        context.assertEquals(buildExpectedJsonObject("getQueuesStatistics"), operation);
+
+        operation = RedisquesAPI.buildGetQueuesStatisticsOperation(null);
+        context.assertEquals(buildExpectedJsonObject("getQueuesStatistics"), operation);
+
+        operation = RedisquesAPI.buildGetQueuesStatisticsOperation("abc");
+        JsonObject expected = buildExpectedJsonObject("getQueuesStatistics", new JsonObject()
+            .put(FILTER, "abc"));
+        context.assertEquals(expected, operation);
+    }
+
+
+
+
     private JsonObject buildExpectedJsonObject(String operation){
         JsonObject expected = new JsonObject();
         expected.put("operation", operation);

--- a/src/test/java/org/swisspush/redisques/util/RedisquesAPITest.java
+++ b/src/test/java/org/swisspush/redisques/util/RedisquesAPITest.java
@@ -310,9 +310,6 @@ public class RedisquesAPITest {
         context.assertEquals(expected, operation);
     }
 
-
-
-
     private JsonObject buildExpectedJsonObject(String operation){
         JsonObject expected = new JsonObject();
         expected.put("operation", operation);


### PR DESCRIPTION
Currently there was only a monitor request which was requesting in a sequence the size of each queue over the vert.x eventbus.  With a high number of queues this is inefficient.  In addition, there is the need for an efficient way to retrieve more queue statistic values about slowdown time and backpressure time. This PR introduces a LUA script fetching all queue sizes in one go and provides as well all statistic values of the queues in one single request.