### PR TITLE
handle null result

### DIFF
--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -136,7 +136,7 @@ public class RedisQues extends AbstractVerticle {
         // Try to register for this queue
         redisSetWithOptions(consumersPrefix + queueName, uid, true, consumerLockTime, event -> {
             if (event.succeeded()) {
-                String value = event.result().toString();
+                String value = event.result() != null ? event.result().toString() : null;
                 if (log.isTraceEnabled()) {
                     log.trace("RedisQues setxn result: " + value + " for queue: " + queueName);
                 }


### PR DESCRIPTION
Discovered this when working on the gateleen integration tests. We need to handle the null case here.