### PR TITLE
#84 / SDCISA-3814 Queue pace (speed) evaluation feature added

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,14 +612,14 @@ Response Data
 ```
 
 
-#### getQueuesPace
+#### getQueuesSpeed
 
 Request Data
 ```
 {
-    "operation": "getQueuesPace",
+    "operation": "getQueuesSpeed",
     "payload": {
-        "filter": <str regex pattern to filter queues to retrieve statistics information (optional)>
+        "filter": <str regex pattern to filter queues to retrieve the cumulated speed (optional)>
     }
 }
 ```
@@ -627,8 +627,8 @@ Request Data
 Response Data
 ```
 {
-    "pace": <Long pace>
-    "unitMs": <Long ms>
+    "speed": <Long speed>
+    "unitSec": <Long seconds>
 }
 ```
 
@@ -976,21 +976,22 @@ The result will be a json object with the statistics information like the exampl
 }
 ```
 
-### Get queue pace
-The pace evaluation collects and calculates the pace of all queues matchting the given filter.
-To get the pace information use
-> GET /queuing/pace
+### Get queue speed
+The speed evaluation collects and calculates the cumulated speed of all queues matchting the given filter.
+To get the speed information use
+> GET /queuing/speed
 
 Available url parameters are:
-* _filter=<regex pattern>_: Filter the queues for which the summarized pace is evaluated
+* _filter=<regex pattern>_: Filter the queues for which the cumulated speed is evaluated
 
-The result will be a json object with the pace of the last measurement period calculated
-over all queues matching the given filter regex
+The result will be a json object with the speed of the last measurement period calculated
+over all queues matching the given filter regex. Additionally the used measurement time in seconds
+is returned (eg. 60 seconds by default)
 
 ```json
 {
-  "pace": 42,
-  "unitMs": 60000
+  "speed": 42,
+  "unitSec": 60
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -611,6 +611,28 @@ Response Data
 }
 ```
 
+
+#### getQueuesPace
+
+Request Data
+```
+{
+    "operation": "getQueuesPace",
+    "payload": {
+        "filter": <str regex pattern to filter queues to retrieve statistics information (optional)>
+    }
+}
+```
+
+Response Data
+```
+{
+    "pace": <Long pace>
+    "unitMs": <Long ms>
+}
+```
+
+
 ## RedisQues HTTP API
 RedisQues provides a HTTP API to modify queues, queue items and get information about queue counts and queue item counts.
 
@@ -953,6 +975,26 @@ The result will be a json object with the statistics information like the exampl
     ]    
 }
 ```
+
+### Get queue pace
+The pace evaluation collects and calculates the pace of all queues matchting the given filter.
+To get the pace information use
+> GET /queuing/pace
+
+Available url parameters are:
+* _filter=<regex pattern>_: Filter the queues for which the summarized pace is evaluated
+
+The result will be a json object with the pace of the last measurement period calculated
+over all queues matching the given filter regex
+
+```json
+{
+  "pace": 42,
+  "unitMs": 60000
+}
+```
+
+
 
 ## Dependencies
 

--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -65,6 +65,7 @@ import org.swisspush.redisques.handler.GetQueueItemsHandler;
 import org.swisspush.redisques.handler.GetQueuesCountHandler;
 import org.swisspush.redisques.handler.GetQueuesHandler;
 import org.swisspush.redisques.handler.GetQueuesItemsCountHandler;
+import org.swisspush.redisques.handler.GetQueuesPaceHandler;
 import org.swisspush.redisques.handler.GetQueuesStatisticsHandler;
 import org.swisspush.redisques.handler.PutLockHandler;
 import org.swisspush.redisques.handler.RedisquesHttpRequestHandler;
@@ -259,7 +260,7 @@ public class RedisQues extends AbstractVerticle {
         this.redisAPI = RedisAPI.api(redisClient);
         this.luaScriptManager = new LuaScriptManager(redisAPI);
         this.queueStatisticsCollector = new QueueStatisticsCollector(redisAPI, luaScriptManager,
-            queuesPrefix);
+            queuesPrefix, vertx, modConfig.getQueueStatisticPaceTime());
 
         RedisquesHttpRequestHandler.init(vertx, modConfig);
 
@@ -368,6 +369,9 @@ public class RedisQues extends AbstractVerticle {
                 case getQueuesStatistics:
                     getQueuesStatistics(event);
                     break;
+                case getQueuesPace:
+                    getQueuesPace(event);
+                    break;
                 default:
                     unsupportedOperation(operation, event);
             }
@@ -411,7 +415,7 @@ public class RedisQues extends AbstractVerticle {
                     } else {
                         log.debug("RedisQues Removing queue " + queue + " from the list");
                         myQueues.remove(queue);
-                        queueStatisticsCollector.resetQueueStatistics(queue);
+                        queueStatisticsCollector.resetQueueFailureStatistics(queue);
                     }
                 });
             });
@@ -584,7 +588,7 @@ public class RedisQues extends AbstractVerticle {
                 // 1st: We don't, to keep backward compatibility
                 // 2nd: We don't, to may unlock below.
             }
-            queueStatisticsCollector.resetQueueStatistics(queue);
+            queueStatisticsCollector.resetQueueFailureStatistics(queue);
             if (unlock) {
                 redisAPI.hdel(Arrays.asList(locksKey, queue), unlockReply -> {
                     if (unlockReply.failed()) {
@@ -601,11 +605,11 @@ public class RedisQues extends AbstractVerticle {
 
     int updateQueueFailureCountAndGetRetryInterval(final String queueName, boolean sendSuccess) {
         if (sendSuccess) {
-            queueStatisticsCollector.resetQueueStatistics(queueName);
+            queueStatisticsCollector.queueMessageSuccess(queueName);
             return 0;
         } else {
             // update the failure count
-            long failureCount = queueStatisticsCollector.incrementQueueFailureCount(queueName);
+            long failureCount = queueStatisticsCollector.queueMessageFailed(queueName);
             // find a retry interval from the queue configurations
             QueueConfiguration queueConfiguration = findQueueConfiguration(queueName);
             if (queueConfiguration != null) {
@@ -1317,7 +1321,7 @@ public class RedisQues extends AbstractVerticle {
                         if (counter.decrementAndGet() == 0) {
                             removeOldQueues(limit);
                         }
-                        queueStatisticsCollector.resetQueueStatistics(queueName);
+                        queueStatisticsCollector.resetQueueFailureStatistics(queueName);
                     }
                 });
             }
@@ -1423,8 +1427,35 @@ public class RedisQues extends AbstractVerticle {
             event.reply(createErrorReply().put(ERROR_TYPE, BAD_INPUT)
                 .put(MESSAGE, filterPattern.getErr()));
         } else {
+            // retrieve all currently known queues from storage and pass this to the handler
             redisAPI.zrangebyscore(List.of(queuesKey, String.valueOf(getMaxAgeTimestamp()), "+inf"),
                 new GetQueuesStatisticsHandler(event, filterPattern.getOk(),
+                    queueStatisticsCollector));
+        }
+    }
+
+    /**
+     * Retrieve the queue statistics info of the requested queues
+     * @param event
+     */
+    private void getQueuesPace(Message<JsonObject> event) {
+        Result<Optional<Pattern>, String> filterPattern = MessageUtil.extractFilterPattern(event);
+        getQueuesPace(event, filterPattern);
+    }
+
+    /**
+     * Retrieve the queue statistics info of the requested queues filtered by the
+     * given filter pattern.
+     */
+    private void getQueuesPace(Message<JsonObject> event,
+        Result<Optional<Pattern>, String> filterPattern) {
+        if (filterPattern.isErr()) {
+            event.reply(createErrorReply().put(ERROR_TYPE, BAD_INPUT)
+                .put(MESSAGE, filterPattern.getErr()));
+        } else {
+            // retrieve all currently known queues from storage and pass this to the handler
+            redisAPI.zrangebyscore(List.of(queuesKey, String.valueOf(getMaxAgeTimestamp()), "+inf"),
+                new GetQueuesPaceHandler(event, filterPattern.getOk(),
                     queueStatisticsCollector));
         }
     }

--- a/src/main/java/org/swisspush/redisques/handler/GetQueuesPaceHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueuesPaceHandler.java
@@ -1,0 +1,46 @@
+package org.swisspush.redisques.handler;
+
+import static org.swisspush.redisques.util.RedisquesAPI.ERROR;
+import static org.swisspush.redisques.util.RedisquesAPI.STATUS;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonObject;
+import io.vertx.redis.client.Response;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.swisspush.redisques.util.QueueHandlerUtil;
+import org.swisspush.redisques.util.QueueStatisticsCollector;
+
+/**
+ * Retrieves in it's AsyncResult handler the pace sum of the queues matching the given filter
+ * and returns the same in the event completion.
+ */
+public class GetQueuesPaceHandler implements Handler<AsyncResult<Response>> {
+
+    private final Message<JsonObject> event;
+    private final Optional<Pattern> filterPattern;
+    private final QueueStatisticsCollector queueStatisticsCollector;
+
+    public GetQueuesPaceHandler(Message<JsonObject> event,
+        Optional<Pattern> filterPattern,
+        QueueStatisticsCollector queueStatisticsCollector) {
+        this.event = event;
+        this.filterPattern = filterPattern;
+        this.queueStatisticsCollector = queueStatisticsCollector;
+    }
+
+    @Override
+    public void handle(AsyncResult<Response> handleQueues) {
+        if (handleQueues.succeeded()) {
+            // apply the given filter in order to have only the queues for which we ar interested
+            List<String> queues = QueueHandlerUtil
+                .filterQueues(handleQueues.result(), filterPattern);
+            queueStatisticsCollector.getQueuesPace(event, queues);
+        } else {
+            event.reply(new JsonObject().put(STATUS, ERROR));
+        }
+    }
+}

--- a/src/main/java/org/swisspush/redisques/handler/GetQueuesSpeedHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueuesSpeedHandler.java
@@ -15,16 +15,16 @@ import org.swisspush.redisques.util.QueueHandlerUtil;
 import org.swisspush.redisques.util.QueueStatisticsCollector;
 
 /**
- * Retrieves in it's AsyncResult handler the pace sum of the queues matching the given filter
+ * Retrieves in it's AsyncResult handler the speed summary of the queues matching the given filter
  * and returns the same in the event completion.
  */
-public class GetQueuesPaceHandler implements Handler<AsyncResult<Response>> {
+public class GetQueuesSpeedHandler implements Handler<AsyncResult<Response>> {
 
     private final Message<JsonObject> event;
     private final Optional<Pattern> filterPattern;
     private final QueueStatisticsCollector queueStatisticsCollector;
 
-    public GetQueuesPaceHandler(Message<JsonObject> event,
+    public GetQueuesSpeedHandler(Message<JsonObject> event,
         Optional<Pattern> filterPattern,
         QueueStatisticsCollector queueStatisticsCollector) {
         this.event = event;
@@ -38,7 +38,7 @@ public class GetQueuesPaceHandler implements Handler<AsyncResult<Response>> {
             // apply the given filter in order to have only the queues for which we ar interested
             List<String> queues = QueueHandlerUtil
                 .filterQueues(handleQueues.result(), filterPattern);
-            queueStatisticsCollector.getQueuesPace(event, queues);
+            queueStatisticsCollector.getQueuesSpeed(event, queues);
         } else {
             event.reply(new JsonObject().put(STATUS, ERROR));
         }

--- a/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
@@ -4,7 +4,43 @@ import static org.swisspush.redisques.util.HttpServerRequestUtil.decode;
 import static org.swisspush.redisques.util.HttpServerRequestUtil.encodePayload;
 import static org.swisspush.redisques.util.HttpServerRequestUtil.evaluateUrlParameterToBeEmptyOrTrue;
 import static org.swisspush.redisques.util.HttpServerRequestUtil.extractNonEmptyJsonArrayFromBody;
-import static org.swisspush.redisques.util.RedisquesAPI.*;
+import static org.swisspush.redisques.util.RedisquesAPI.BAD_INPUT;
+import static org.swisspush.redisques.util.RedisquesAPI.COUNT;
+import static org.swisspush.redisques.util.RedisquesAPI.ERROR_TYPE;
+import static org.swisspush.redisques.util.RedisquesAPI.FILTER;
+import static org.swisspush.redisques.util.RedisquesAPI.LIMIT;
+import static org.swisspush.redisques.util.RedisquesAPI.LOCKS;
+import static org.swisspush.redisques.util.RedisquesAPI.MESSAGE;
+import static org.swisspush.redisques.util.RedisquesAPI.MONITOR_QUEUE_SIZE;
+import static org.swisspush.redisques.util.RedisquesAPI.NO_SUCH_LOCK;
+import static org.swisspush.redisques.util.RedisquesAPI.OK;
+import static org.swisspush.redisques.util.RedisquesAPI.QUEUES;
+import static org.swisspush.redisques.util.RedisquesAPI.STATUS;
+import static org.swisspush.redisques.util.RedisquesAPI.VALUE;
+import static org.swisspush.redisques.util.RedisquesAPI.buildAddQueueItemOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildBulkDeleteLocksOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildBulkDeleteQueuesOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildBulkPutLocksOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildDeleteAllLocksOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildDeleteAllQueueItemsOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildDeleteLockOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildDeleteQueueItemOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildEnqueueOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetAllLocksOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetConfigurationOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetLockOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueueItemOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueueItemsCountOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueueItemsOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueuesCountOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueuesItemsCountOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueuesOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueuesStatisticsOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildLockedEnqueueOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildPutLockOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildReplaceQueueItemOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildSetConfigurationOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueuesPaceOperation;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -26,6 +62,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.swisspush.redisques.util.RedisquesAPI;
 import org.swisspush.redisques.util.RedisquesConfiguration;
 import org.swisspush.redisques.util.Result;
 import org.swisspush.redisques.util.StatusCode;
@@ -54,6 +91,7 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
     private final String redisquesAddress;
     private final String userHeader;
     private final boolean enableQueueNameDecoding;
+    private final int paceTime;
 
     public static void init(Vertx vertx, RedisquesConfiguration modConfig) {
         log.info("Enable http request handler: " + modConfig.getHttpRequestHandlerEnabled());
@@ -81,6 +119,7 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
         this.redisquesAddress = modConfig.getAddress();
         this.userHeader = modConfig.getHttpRequestHandlerUserHeader();
         this.enableQueueNameDecoding = modConfig.getEnableQueueNameDecoding();
+        this.paceTime = modConfig.getQueueStatisticPaceTime();
 
         final String prefix = modConfig.getHttpRequestHandlerPrefix();
 
@@ -108,6 +147,11 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
          * Get statistic information
          */
         router.get(prefix + "/statistics").handler(this::getQueuesStatistics);
+
+        /*
+         * Get pace information
+         */
+        router.get(prefix + "/pace").handler(this::getQueuesPace);
 
         /*
          * Enqueue or LockedEnqueue
@@ -849,8 +893,28 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
                     log.error(error);
                     respondWith(StatusCode.INTERNAL_SERVER_ERROR, error, ctx.request());
                 }
-
             });
     }
+
+    private void getQueuesPace(RoutingContext ctx) {
+        String filter = ctx.request().params().get(FILTER);
+        eventBus.request(redisquesAddress, buildGetQueuesPaceOperation(filter),
+            (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
+                if (reply.succeeded() && reply.result().body().getString(RedisquesAPI.STATISTIC_QUEUE_PACE) != null) {
+                    long pace = reply.result().body().getLong(RedisquesAPI.STATISTIC_QUEUE_PACE);
+                    JsonObject resultObject = new JsonObject();
+                    resultObject.put(RedisquesAPI.STATISTIC_QUEUE_PACE, pace);
+                    resultObject.put(RedisquesAPI.STATISTIC_QUEUE_PACE_UNIT, paceTime );
+                    jsonResponse(ctx.response(), resultObject);
+                } else {
+                    // there was no result, we as well return an empty result
+                    JsonObject resultObject = new JsonObject();
+                    resultObject.put(RedisquesAPI.STATISTIC_QUEUE_PACE, 0L);
+                    jsonResponse(ctx.response(), resultObject);
+                }
+            });
+    }
+
+
 
 }

--- a/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
+++ b/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
@@ -41,8 +41,8 @@ public class RedisquesAPI {
     public static final String STATISTIC_QUEUE_FAILURES = "failures";
     public static final String STATISTIC_QUEUE_BACKPRESSURE = "backpressureTime";
     public static final String STATISTIC_QUEUE_SLOWDOWN = "slowdownTime";
-    public static final String STATISTIC_QUEUE_PACE = "pace";
-    public static final String STATISTIC_QUEUE_PACE_UNIT= "unitMs";
+    public static final String STATISTIC_QUEUE_SPEED = "speed";
+    public static final String STATISTIC_QUEUE_SPEED_INTERVAL_UNIT= "unitMs";
 
     private static Logger log = LoggerFactory.getLogger(RedisquesAPI.class);
 
@@ -73,7 +73,7 @@ public class RedisquesAPI {
         getQueueItemsCount(null),
         getQueuesItemsCount(null),
         getQueuesStatistics(null),
-        getQueuesPace(null);
+        getQueuesSpeed(null);
 
         private final String legacyName;
 
@@ -274,23 +274,23 @@ public class RedisquesAPI {
 
     /**
      *
-     * Retrieve total pace over all queues if no filter given
-     * @return The total pace overall
+     * Retrieve total speed over all queues if no filter given
+     * @return The total speed overall
      */
-    public static JsonObject buildGetQueuesPaceOperation() {
-        return buildOperation(QueueOperation.getQueuesPace);
+    public static JsonObject buildGetQueuesSpeedOperation() {
+        return buildOperation(QueueOperation.getQueuesSpeed);
     }
 
     /**
-     * Retrieve pace for all the queues matching the given filter
-     * @param filterPattern The queues filter for which we would like to get the total pace
+     * Retrieve speed for all the queues matching the given filter
+     * @param filterPattern The queues filter for which we would like to get the total speed
      *      Filter pattern. Method handles {@code null} gracefully.
      */
-    public static JsonObject buildGetQueuesPaceOperation(String filterPattern) {
+    public static JsonObject buildGetQueuesSpeedOperation(String filterPattern) {
         if (filterPattern != null) {
-            return buildOperation(QueueOperation.getQueuesPace, new JsonObject().put(FILTER, filterPattern));
+            return buildOperation(QueueOperation.getQueuesSpeed, new JsonObject().put(FILTER, filterPattern));
         }
-        return buildGetQueuesPaceOperation();
+        return buildGetQueuesSpeedOperation();
     }
 
 

--- a/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
+++ b/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
@@ -41,7 +41,8 @@ public class RedisquesAPI {
     public static final String STATISTIC_QUEUE_FAILURES = "failures";
     public static final String STATISTIC_QUEUE_BACKPRESSURE = "backpressureTime";
     public static final String STATISTIC_QUEUE_SLOWDOWN = "slowdownTime";
-
+    public static final String STATISTIC_QUEUE_PACE = "pace";
+    public static final String STATISTIC_QUEUE_PACE_UNIT= "unitMs";
 
     private static Logger log = LoggerFactory.getLogger(RedisquesAPI.class);
 
@@ -71,7 +72,8 @@ public class RedisquesAPI {
         getQueuesCount(null),
         getQueueItemsCount(null),
         getQueuesItemsCount(null),
-        getQueuesStatistics(null);
+        getQueuesStatistics(null),
+        getQueuesPace(null);
 
         private final String legacyName;
 
@@ -269,5 +271,27 @@ public class RedisquesAPI {
         }
         return buildGetQueuesStatisticsOperation();
     }
+
+    /**
+     *
+     * Retrieve total pace over all queues if no filter given
+     * @return The total pace overall
+     */
+    public static JsonObject buildGetQueuesPaceOperation() {
+        return buildOperation(QueueOperation.getQueuesPace);
+    }
+
+    /**
+     * Retrieve pace for all the queues matching the given filter
+     * @param filterPattern The queues filter for which we would like to get the total pace
+     *      Filter pattern. Method handles {@code null} gracefully.
+     */
+    public static JsonObject buildGetQueuesPaceOperation(String filterPattern) {
+        if (filterPattern != null) {
+            return buildOperation(QueueOperation.getQueuesPace, new JsonObject().put(FILTER, filterPattern));
+        }
+        return buildGetQueuesPaceOperation();
+    }
+
 
 }

--- a/src/main/java/org/swisspush/redisques/util/RedisquesConfiguration.java
+++ b/src/main/java/org/swisspush/redisques/util/RedisquesConfiguration.java
@@ -35,6 +35,7 @@ public class RedisquesConfiguration {
     private boolean enableQueueNameDecoding;
     private int maxPoolSize;
     private int maxWaitSize;
+    private int queueStatisticPaceTime;
 
     private static final int DEFAULT_CHECK_INTERVAL = 60; // 60s
     private static final long DEFAULT_PROCESSOR_DELAY_MAX = 0;
@@ -46,6 +47,7 @@ public class RedisquesConfiguration {
     // - https://vertx.io/docs/apidocs/io/vertx/redis/client/RedisOptions.html#setMaxPoolWaiting-int-
     // - https://stackoverflow.com/questions/59692663/vertx-java-httpclient-how-to-derive-maxpoolsize-and-maxwaitqueuesize-values-and
     private static final int DEFAULT_REDIS_MAX_WAIT_SIZE = -1;
+    private static final int DEFAULT_QUEUE_STATISTIC_PACE_TIME = 60000;
 
     public static final String PROP_ADDRESS = "address";
     public static final String PROP_CONFIGURATION_UPDATED_ADDRESS = "configuration-updated-address";
@@ -67,6 +69,7 @@ public class RedisquesConfiguration {
     public static final String PROP_ENABLE_QUEUE_NAME_DECODING = "enableQueueNameDecoding";
     public static final String PROP_REDIS_MAX_POOL_SIZE = "maxPoolSize";
     public static final String PROP_REDIS_MAX_WAIT_SIZE = "maxWaitSize";
+    public static final String PROP_QUEUE_STATISTIC_PACE_TIME = "queueStatisticPaceTime";
 
     /**
      * Constructor with default values. Use the {@link RedisquesConfigurationBuilder} class
@@ -87,7 +90,8 @@ public class RedisquesConfiguration {
                 processorTimeout, processorDelayMax, httpRequestHandlerEnabled,
                 httpRequestHandlerPrefix, httpRequestHandlerPort,
                 httpRequestHandlerUserHeader, queueConfigurations,
-                enableQueueNameDecoding, DEFAULT_REDIS_MAX_POOL_SIZE, DEFAULT_REDIS_MAX_WAIT_SIZE);
+                enableQueueNameDecoding, DEFAULT_REDIS_MAX_POOL_SIZE, DEFAULT_REDIS_MAX_WAIT_SIZE,
+                DEFAULT_QUEUE_STATISTIC_PACE_TIME);
     }
 
     public RedisquesConfiguration(String address, String configurationUpdatedAddress, String redisPrefix, String processorAddress, int refreshPeriod,
@@ -95,7 +99,8 @@ public class RedisquesConfiguration {
                                   int processorTimeout, long processorDelayMax, boolean httpRequestHandlerEnabled,
                                   String httpRequestHandlerPrefix, Integer httpRequestHandlerPort,
                                   String httpRequestHandlerUserHeader, List<QueueConfiguration> queueConfigurations,
-                                  boolean enableQueueNameDecoding, int maxPoolSize, int maxWaitSize) {
+                                  boolean enableQueueNameDecoding, int maxPoolSize, int maxWaitSize,
+                                  int queueStatisticPaceTime) {
         this.address = address;
         this.configurationUpdatedAddress = configurationUpdatedAddress;
         this.redisPrefix = redisPrefix;
@@ -107,7 +112,6 @@ public class RedisquesConfiguration {
         this.redisEncoding = redisEncoding;
         this.maxPoolSize = maxPoolSize;
         this.maxWaitSize = maxWaitSize;
-
         Logger log = LoggerFactory.getLogger(RedisquesConfiguration.class);
 
         if (checkInterval > 0) {
@@ -132,6 +136,7 @@ public class RedisquesConfiguration {
         this.httpRequestHandlerUserHeader = httpRequestHandlerUserHeader;
         this.queueConfigurations = queueConfigurations;
         this.enableQueueNameDecoding = enableQueueNameDecoding;
+        this.queueStatisticPaceTime = queueStatisticPaceTime;
     }
 
     public static RedisquesConfigurationBuilder with() {
@@ -145,7 +150,8 @@ public class RedisquesConfiguration {
             builder.processorTimeout, builder.processorDelayMax, builder.httpRequestHandlerEnabled,
             builder.httpRequestHandlerPrefix, builder.httpRequestHandlerPort,
             builder.httpRequestHandlerUserHeader, builder.queueConfigurations,
-            builder.enableQueueNameDecoding, builder.maxPoolSize, builder.maxWaitSize);
+            builder.enableQueueNameDecoding, builder.maxPoolSize, builder.maxWaitSize,
+            builder.queueStatisticPaceTime);
     }
 
     public JsonObject asJsonObject() {
@@ -169,6 +175,7 @@ public class RedisquesConfiguration {
         obj.put(PROP_QUEUE_CONFIGURATIONS, new JsonArray(getQueueConfigurations().stream().map(QueueConfiguration::asJsonObject).collect(Collectors.toList())));
         obj.put(PROP_ENABLE_QUEUE_NAME_DECODING, getEnableQueueNameDecoding());
         obj.put(PROP_REDIS_MAX_POOL_SIZE, getMaxPoolSize());
+        obj.put(PROP_QUEUE_STATISTIC_PACE_TIME, getQueueStatisticPaceTime());
         return obj;
     }
 
@@ -233,6 +240,9 @@ public class RedisquesConfiguration {
         }
         if (json.containsKey(PROP_REDIS_MAX_POOL_SIZE)) {
             builder.maxPoolSize(json.getInteger(PROP_REDIS_MAX_POOL_SIZE));
+        }
+        if (json.containsKey(PROP_QUEUE_STATISTIC_PACE_TIME)) {
+            builder.queueStatisticPaceTime(json.getInteger(PROP_QUEUE_STATISTIC_PACE_TIME));
         }
         return builder.build();
     }
@@ -327,6 +337,14 @@ public class RedisquesConfiguration {
         return maxWaitSize;
     }
 
+    /**
+     * Retrieves the interval time in ms in which the queue statistics message pace is calculated
+     * @return The pace interval time in ms
+     */
+    public int getQueueStatisticPaceTime() {
+        return queueStatisticPaceTime;
+    }
+
     @Override
     public String toString() {
         return asJsonObject().toString();
@@ -364,6 +382,7 @@ public class RedisquesConfiguration {
         private boolean enableQueueNameDecoding;
         private int maxPoolSize;
         private int maxWaitSize;
+        private int queueStatisticPaceTime;
 
         public RedisquesConfigurationBuilder() {
             this.address = "redisques";
@@ -385,6 +404,7 @@ public class RedisquesConfiguration {
             this.enableQueueNameDecoding = true;
             this.maxPoolSize = DEFAULT_REDIS_MAX_POOL_SIZE;
             this.maxWaitSize = DEFAULT_REDIS_MAX_WAIT_SIZE;
+            this.queueStatisticPaceTime = DEFAULT_QUEUE_STATISTIC_PACE_TIME;
         }
 
         public RedisquesConfigurationBuilder address(String address) {
@@ -487,6 +507,10 @@ public class RedisquesConfiguration {
             return this;
         }
 
+        public RedisquesConfigurationBuilder queueStatisticPaceTime(int queueStatisticPaceTime) {
+            this.queueStatisticPaceTime = queueStatisticPaceTime;
+            return this;
+        }
 
         public RedisquesConfiguration build() {
             return new RedisquesConfiguration(this);

--- a/src/main/java/org/swisspush/redisques/util/RedisquesConfiguration.java
+++ b/src/main/java/org/swisspush/redisques/util/RedisquesConfiguration.java
@@ -35,7 +35,7 @@ public class RedisquesConfiguration {
     private boolean enableQueueNameDecoding;
     private int maxPoolSize;
     private int maxWaitSize;
-    private int queueStatisticPaceTime;
+    private int queueSpeedIntervalSec;
 
     private static final int DEFAULT_CHECK_INTERVAL = 60; // 60s
     private static final long DEFAULT_PROCESSOR_DELAY_MAX = 0;
@@ -47,7 +47,7 @@ public class RedisquesConfiguration {
     // - https://vertx.io/docs/apidocs/io/vertx/redis/client/RedisOptions.html#setMaxPoolWaiting-int-
     // - https://stackoverflow.com/questions/59692663/vertx-java-httpclient-how-to-derive-maxpoolsize-and-maxwaitqueuesize-values-and
     private static final int DEFAULT_REDIS_MAX_WAIT_SIZE = -1;
-    private static final int DEFAULT_QUEUE_STATISTIC_PACE_TIME = 60000;
+    private static final int DEFAULT_QUEUE_SPEED_INTERVAL_SEC = 60;
 
     public static final String PROP_ADDRESS = "address";
     public static final String PROP_CONFIGURATION_UPDATED_ADDRESS = "configuration-updated-address";
@@ -68,8 +68,7 @@ public class RedisquesConfiguration {
     public static final String PROP_QUEUE_CONFIGURATIONS = "queueConfigurations";
     public static final String PROP_ENABLE_QUEUE_NAME_DECODING = "enableQueueNameDecoding";
     public static final String PROP_REDIS_MAX_POOL_SIZE = "maxPoolSize";
-    public static final String PROP_REDIS_MAX_WAIT_SIZE = "maxWaitSize";
-    public static final String PROP_QUEUE_STATISTIC_PACE_TIME = "queueStatisticPaceTime";
+    public static final String PROP_QUEUE_SPEED_INTERVAL_SEC = "queueSpeedIntervalSec";
 
     /**
      * Constructor with default values. Use the {@link RedisquesConfigurationBuilder} class
@@ -91,7 +90,7 @@ public class RedisquesConfiguration {
                 httpRequestHandlerPrefix, httpRequestHandlerPort,
                 httpRequestHandlerUserHeader, queueConfigurations,
                 enableQueueNameDecoding, DEFAULT_REDIS_MAX_POOL_SIZE, DEFAULT_REDIS_MAX_WAIT_SIZE,
-                DEFAULT_QUEUE_STATISTIC_PACE_TIME);
+                DEFAULT_QUEUE_SPEED_INTERVAL_SEC);
     }
 
     public RedisquesConfiguration(String address, String configurationUpdatedAddress, String redisPrefix, String processorAddress, int refreshPeriod,
@@ -100,7 +99,7 @@ public class RedisquesConfiguration {
                                   String httpRequestHandlerPrefix, Integer httpRequestHandlerPort,
                                   String httpRequestHandlerUserHeader, List<QueueConfiguration> queueConfigurations,
                                   boolean enableQueueNameDecoding, int maxPoolSize, int maxWaitSize,
-                                  int queueStatisticPaceTime) {
+                                  int queueSpeedIntervalSec) {
         this.address = address;
         this.configurationUpdatedAddress = configurationUpdatedAddress;
         this.redisPrefix = redisPrefix;
@@ -136,7 +135,7 @@ public class RedisquesConfiguration {
         this.httpRequestHandlerUserHeader = httpRequestHandlerUserHeader;
         this.queueConfigurations = queueConfigurations;
         this.enableQueueNameDecoding = enableQueueNameDecoding;
-        this.queueStatisticPaceTime = queueStatisticPaceTime;
+        this.queueSpeedIntervalSec = queueSpeedIntervalSec;
     }
 
     public static RedisquesConfigurationBuilder with() {
@@ -151,7 +150,7 @@ public class RedisquesConfiguration {
             builder.httpRequestHandlerPrefix, builder.httpRequestHandlerPort,
             builder.httpRequestHandlerUserHeader, builder.queueConfigurations,
             builder.enableQueueNameDecoding, builder.maxPoolSize, builder.maxWaitSize,
-            builder.queueStatisticPaceTime);
+            builder.queueSpeedIntervalSec);
     }
 
     public JsonObject asJsonObject() {
@@ -175,7 +174,7 @@ public class RedisquesConfiguration {
         obj.put(PROP_QUEUE_CONFIGURATIONS, new JsonArray(getQueueConfigurations().stream().map(QueueConfiguration::asJsonObject).collect(Collectors.toList())));
         obj.put(PROP_ENABLE_QUEUE_NAME_DECODING, getEnableQueueNameDecoding());
         obj.put(PROP_REDIS_MAX_POOL_SIZE, getMaxPoolSize());
-        obj.put(PROP_QUEUE_STATISTIC_PACE_TIME, getQueueStatisticPaceTime());
+        obj.put(PROP_QUEUE_SPEED_INTERVAL_SEC, getQueueSpeedIntervalSec());
         return obj;
     }
 
@@ -241,8 +240,8 @@ public class RedisquesConfiguration {
         if (json.containsKey(PROP_REDIS_MAX_POOL_SIZE)) {
             builder.maxPoolSize(json.getInteger(PROP_REDIS_MAX_POOL_SIZE));
         }
-        if (json.containsKey(PROP_QUEUE_STATISTIC_PACE_TIME)) {
-            builder.queueStatisticPaceTime(json.getInteger(PROP_QUEUE_STATISTIC_PACE_TIME));
+        if (json.containsKey(PROP_QUEUE_SPEED_INTERVAL_SEC)) {
+            builder.queueSpeedIntervalSec(json.getInteger(PROP_QUEUE_SPEED_INTERVAL_SEC));
         }
         return builder.build();
     }
@@ -338,11 +337,11 @@ public class RedisquesConfiguration {
     }
 
     /**
-     * Retrieves the interval time in ms in which the queue statistics message pace is calculated
-     * @return The pace interval time in ms
+     * Retrieves the interval time in seconds in which the queue speed is calculated
+     * @return The speed interval time in seconds
      */
-    public int getQueueStatisticPaceTime() {
-        return queueStatisticPaceTime;
+    public int getQueueSpeedIntervalSec() {
+        return queueSpeedIntervalSec;
     }
 
     @Override
@@ -382,7 +381,7 @@ public class RedisquesConfiguration {
         private boolean enableQueueNameDecoding;
         private int maxPoolSize;
         private int maxWaitSize;
-        private int queueStatisticPaceTime;
+        private int queueSpeedIntervalSec;
 
         public RedisquesConfigurationBuilder() {
             this.address = "redisques";
@@ -404,7 +403,7 @@ public class RedisquesConfiguration {
             this.enableQueueNameDecoding = true;
             this.maxPoolSize = DEFAULT_REDIS_MAX_POOL_SIZE;
             this.maxWaitSize = DEFAULT_REDIS_MAX_WAIT_SIZE;
-            this.queueStatisticPaceTime = DEFAULT_QUEUE_STATISTIC_PACE_TIME;
+            this.queueSpeedIntervalSec = DEFAULT_QUEUE_SPEED_INTERVAL_SEC;
         }
 
         public RedisquesConfigurationBuilder address(String address) {
@@ -507,8 +506,8 @@ public class RedisquesConfiguration {
             return this;
         }
 
-        public RedisquesConfigurationBuilder queueStatisticPaceTime(int queueStatisticPaceTime) {
-            this.queueStatisticPaceTime = queueStatisticPaceTime;
+        public RedisquesConfigurationBuilder queueSpeedIntervalSec(int queueSpeedIntervalSec) {
+            this.queueSpeedIntervalSec = queueSpeedIntervalSec;
             return this;
         }
 

--- a/src/test/java/org/swisspush/redisques/util/RedisquesConfigurationTest.java
+++ b/src/test/java/org/swisspush/redisques/util/RedisquesConfigurationTest.java
@@ -40,6 +40,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(config.getHttpRequestHandlerPort(), 7070);
         testContext.assertEquals(config.getHttpRequestHandlerUserHeader(), "x-rp-usr");
         testContext.assertEquals(config.getQueueConfigurations().size(), 0);
+        testContext.assertEquals(config.getQueueStatisticPaceTime(),60000);
     }
 
     @Test
@@ -60,6 +61,7 @@ public class RedisquesConfigurationTest {
                 .queueConfigurations(Collections.singletonList(
                         new QueueConfiguration().withPattern("vehicle-.*").withRetryIntervals(10, 20, 30, 60)
                 ))
+                .queueStatisticPaceTime(1000)
                 .build();
 
         // default values
@@ -80,7 +82,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(config.getHttpRequestHandlerPrefix(), "/queuing/test");
         testContext.assertEquals(config.getHttpRequestHandlerPort(), 7171);
         testContext.assertEquals(config.getHttpRequestHandlerUserHeader(), "x-custom-user-header");
-
+        testContext.assertEquals(config.getQueueStatisticPaceTime(), 1000);
         // queue configurations
         testContext.assertEquals(config.getQueueConfigurations().size(), 1);
         QueueConfiguration queueConfiguration = config.getQueueConfigurations().get(0);
@@ -109,6 +111,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(json.getInteger(PROP_HTTP_REQUEST_HANDLER_PORT), 7070);
         testContext.assertEquals(json.getString(PROP_HTTP_REQUEST_HANDLER_USER_HEADER), "x-rp-usr");
         testContext.assertEquals(json.getJsonArray(PROP_QUEUE_CONFIGURATIONS).getList().size(), 0);
+        testContext.assertEquals(json.getInteger(PROP_QUEUE_STATISTIC_PACE_TIME), 60000);
     }
 
     @Test
@@ -127,6 +130,7 @@ public class RedisquesConfigurationTest {
                 .queueConfigurations(Collections.singletonList(
                         new QueueConfiguration().withPattern("vehicle-.*").withRetryIntervals(10, 20, 30, 60)
                 ))
+                .queueStatisticPaceTime(1000)
                 .build();
 
         JsonObject json = config.asJsonObject();
@@ -149,6 +153,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(json.getInteger(PROP_PROCESSOR_DELAY_MAX), 50);
         testContext.assertEquals(json.getInteger(PROP_HTTP_REQUEST_HANDLER_PORT), 7171);
         testContext.assertEquals(json.getString(PROP_HTTP_REQUEST_HANDLER_USER_HEADER), "x-custom-user-header");
+        testContext.assertEquals(json.getInteger(PROP_QUEUE_STATISTIC_PACE_TIME), 1000);
 
         // queue configurations
         JsonArray queueConfigurationsJsonArray = json.getJsonArray(PROP_QUEUE_CONFIGURATIONS);
@@ -180,6 +185,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(config.getHttpRequestHandlerPort(), 7070);
         testContext.assertEquals(config.getHttpRequestHandlerUserHeader(), "x-rp-usr");
         testContext.assertEquals(config.getQueueConfigurations().size(), 0);
+        testContext.assertEquals(config.getQueueStatisticPaceTime(), 60000);
     }
 
     @Test
@@ -201,6 +207,7 @@ public class RedisquesConfigurationTest {
         json.put(PROP_HTTP_REQUEST_HANDLER_PREFIX, "/queuing/test123");
         json.put(PROP_HTTP_REQUEST_HANDLER_PORT, 7171);
         json.put(PROP_HTTP_REQUEST_HANDLER_USER_HEADER, "x-custom-user-header");
+        json.put(PROP_QUEUE_STATISTIC_PACE_TIME, 1000);
         json.put(PROP_QUEUE_CONFIGURATIONS, new JsonArray(Collections.singletonList(
                 new QueueConfiguration().withPattern("vehicle-.*")
                         .withRetryIntervals(10, 20, 30, 60)
@@ -223,6 +230,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(config.getHttpRequestHandlerPort(), 7171);
         testContext.assertEquals(config.getHttpRequestHandlerPrefix(), "/queuing/test123");
         testContext.assertEquals(config.getHttpRequestHandlerUserHeader(), "x-custom-user-header");
+        testContext.assertEquals(config.getQueueStatisticPaceTime(), 1000);
 
         // queue configurations
         testContext.assertEquals(config.getQueueConfigurations().size(), 1);

--- a/src/test/java/org/swisspush/redisques/util/RedisquesConfigurationTest.java
+++ b/src/test/java/org/swisspush/redisques/util/RedisquesConfigurationTest.java
@@ -40,7 +40,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(config.getHttpRequestHandlerPort(), 7070);
         testContext.assertEquals(config.getHttpRequestHandlerUserHeader(), "x-rp-usr");
         testContext.assertEquals(config.getQueueConfigurations().size(), 0);
-        testContext.assertEquals(config.getQueueStatisticPaceTime(),60000);
+        testContext.assertEquals(config.getQueueSpeedIntervalSec(),60);
     }
 
     @Test
@@ -61,7 +61,7 @@ public class RedisquesConfigurationTest {
                 .queueConfigurations(Collections.singletonList(
                         new QueueConfiguration().withPattern("vehicle-.*").withRetryIntervals(10, 20, 30, 60)
                 ))
-                .queueStatisticPaceTime(1000)
+                .queueSpeedIntervalSec(1)
                 .build();
 
         // default values
@@ -82,7 +82,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(config.getHttpRequestHandlerPrefix(), "/queuing/test");
         testContext.assertEquals(config.getHttpRequestHandlerPort(), 7171);
         testContext.assertEquals(config.getHttpRequestHandlerUserHeader(), "x-custom-user-header");
-        testContext.assertEquals(config.getQueueStatisticPaceTime(), 1000);
+        testContext.assertEquals(config.getQueueSpeedIntervalSec(), 1);
         // queue configurations
         testContext.assertEquals(config.getQueueConfigurations().size(), 1);
         QueueConfiguration queueConfiguration = config.getQueueConfigurations().get(0);
@@ -111,7 +111,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(json.getInteger(PROP_HTTP_REQUEST_HANDLER_PORT), 7070);
         testContext.assertEquals(json.getString(PROP_HTTP_REQUEST_HANDLER_USER_HEADER), "x-rp-usr");
         testContext.assertEquals(json.getJsonArray(PROP_QUEUE_CONFIGURATIONS).getList().size(), 0);
-        testContext.assertEquals(json.getInteger(PROP_QUEUE_STATISTIC_PACE_TIME), 60000);
+        testContext.assertEquals(json.getInteger(PROP_QUEUE_SPEED_INTERVAL_SEC), 60);
     }
 
     @Test
@@ -130,7 +130,7 @@ public class RedisquesConfigurationTest {
                 .queueConfigurations(Collections.singletonList(
                         new QueueConfiguration().withPattern("vehicle-.*").withRetryIntervals(10, 20, 30, 60)
                 ))
-                .queueStatisticPaceTime(1000)
+                .queueSpeedIntervalSec(1)
                 .build();
 
         JsonObject json = config.asJsonObject();
@@ -153,7 +153,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(json.getInteger(PROP_PROCESSOR_DELAY_MAX), 50);
         testContext.assertEquals(json.getInteger(PROP_HTTP_REQUEST_HANDLER_PORT), 7171);
         testContext.assertEquals(json.getString(PROP_HTTP_REQUEST_HANDLER_USER_HEADER), "x-custom-user-header");
-        testContext.assertEquals(json.getInteger(PROP_QUEUE_STATISTIC_PACE_TIME), 1000);
+        testContext.assertEquals(json.getInteger(PROP_QUEUE_SPEED_INTERVAL_SEC), 1);
 
         // queue configurations
         JsonArray queueConfigurationsJsonArray = json.getJsonArray(PROP_QUEUE_CONFIGURATIONS);
@@ -185,7 +185,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(config.getHttpRequestHandlerPort(), 7070);
         testContext.assertEquals(config.getHttpRequestHandlerUserHeader(), "x-rp-usr");
         testContext.assertEquals(config.getQueueConfigurations().size(), 0);
-        testContext.assertEquals(config.getQueueStatisticPaceTime(), 60000);
+        testContext.assertEquals(config.getQueueSpeedIntervalSec(), 60);
     }
 
     @Test
@@ -207,7 +207,7 @@ public class RedisquesConfigurationTest {
         json.put(PROP_HTTP_REQUEST_HANDLER_PREFIX, "/queuing/test123");
         json.put(PROP_HTTP_REQUEST_HANDLER_PORT, 7171);
         json.put(PROP_HTTP_REQUEST_HANDLER_USER_HEADER, "x-custom-user-header");
-        json.put(PROP_QUEUE_STATISTIC_PACE_TIME, 1000);
+        json.put(PROP_QUEUE_SPEED_INTERVAL_SEC, 1);
         json.put(PROP_QUEUE_CONFIGURATIONS, new JsonArray(Collections.singletonList(
                 new QueueConfiguration().withPattern("vehicle-.*")
                         .withRetryIntervals(10, 20, 30, 60)
@@ -230,7 +230,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(config.getHttpRequestHandlerPort(), 7171);
         testContext.assertEquals(config.getHttpRequestHandlerPrefix(), "/queuing/test123");
         testContext.assertEquals(config.getHttpRequestHandlerUserHeader(), "x-custom-user-header");
-        testContext.assertEquals(config.getQueueStatisticPaceTime(), 1000);
+        testContext.assertEquals(config.getQueueSpeedIntervalSec(), 1);
 
         // queue configurations
         testContext.assertEquals(config.getQueueConfigurations().size(), 1);


### PR DESCRIPTION
Additional feature allowing to evaluate the message pace for a certain queue or group of queues defined by a regex filter. This allows to easily evaluate the pace as well for queues which are dynamically labelled by given header discrimators. 